### PR TITLE
This commit supports multiple Wire objects on those boards which have

### DIFF
--- a/Wire.cpp
+++ b/Wire.cpp
@@ -22,373 +22,239 @@
 #include "Wire.h"
 
 #if defined(__arm__) && defined(CORE_TEENSY)
-
 #include "kinetis.h"
 #include <string.h> // for memcpy
 #include "core_pins.h"
 //#include "HardwareSerial.h"
 #include "Wire.h"
 
-uint8_t TwoWire::rxBuffer[BUFFER_LENGTH];
-uint8_t TwoWire::rxBufferIndex = 0;
-uint8_t TwoWire::rxBufferLength = 0;
-uint8_t TwoWire::txBuffer[BUFFER_LENGTH+1];
-uint8_t TwoWire::txBufferIndex = 0;
-uint8_t TwoWire::txBufferLength = 0;
-uint8_t TwoWire::transmitting = 0;
-uint8_t TwoWire::sda_pin_num = 18;
-uint8_t TwoWire::scl_pin_num = 19;
-void (*TwoWire::user_onRequest)(void) = NULL;
-void (*TwoWire::user_onReceive)(int) = NULL;
-
 
 TwoWire::TwoWire()
 {
+	_pwires = NULL;		// We have not allocated it yet. 
+#if 0
+    receiving = 0;      // Our we receiving...
+    irqcount = 0;
+    transmitting = 0;
+    rxBufferIndex = 0;
+	rxBufferLength = 0;
+	txBufferIndex = 0;
+	txBufferLength = 0;
+#endif
 }
 
-static uint8_t slave_mode = 0;
-static uint8_t irqcount=0;
-
-
-void TwoWire::begin(void)
+void TwoWire::checkAndAllocateStruct() 
 {
-	//serial_begin(BAUD2DIV(115200));
-	//serial_print("\nWire Begin\n");
+	if (!_pwires) {
+		_pwires = (WIRE_STRUCT *)malloc (sizeof(WIRE_STRUCT));
+		if (!_pwires) {
+			return;	// failed to allocate?
+		}
 
-	slave_mode = 0;
-	SIM_SCGC4 |= SIM_SCGC4_I2C0; // TODO: use bitband
-	I2C0_C1 = 0;
-	// On Teensy 3.0 external pullup resistors *MUST* be used
-	// the PORT_PCR_PE bit is ignored when in I2C mode
-	// I2C will not work at all without pullup resistors
-	// It might seem like setting PORT_PCR_PE & PORT_PCR_PS
-	// would enable pullup resistors.  However, there seems
-	// to be a bug in chip while I2C is enabled, where setting
-	// those causes the port to be driven strongly high.
-	if (sda_pin_num == 18) {
-		CORE_PIN18_CONFIG = PORT_PCR_MUX(2)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
-	} else if (sda_pin_num == 17) {
-		CORE_PIN17_CONFIG = PORT_PCR_MUX(2)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
-#if defined(__MK64FX512__) || defined(__MK66FX1M0__)
-	} else if (sda_pin_num == 34) {
-		CORE_PIN34_CONFIG = PORT_PCR_MUX(5)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
-	} else if (sda_pin_num == 8) {
-		CORE_PIN8_CONFIG = PORT_PCR_MUX(7)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
-	} else if (sda_pin_num == 48) {
-		CORE_PIN48_CONFIG = PORT_PCR_MUX(2)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
-#endif	
+	    _pwires->receiving = 0;      // Our we receiving...
+	    _pwires->irqcount = 0;
+	    _pwires->transmitting = 0;
+	    _pwires->rxBufferIndex = 0;
+		_pwires->rxBufferLength = 0;
+		_pwires->txBufferIndex = 0;
+		_pwires->txBufferLength = 0;
+
+	    _pwires->user_onRequest = 0;
+	    _pwires->user_onReceive = 0;
 	}
-	if (scl_pin_num == 19) {
-		CORE_PIN19_CONFIG = PORT_PCR_MUX(2)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
-	} else if (scl_pin_num == 16) {
-		CORE_PIN16_CONFIG = PORT_PCR_MUX(2)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
-#if defined(__MK64FX512__) || defined(__MK66FX1M0__)
-	} else if (scl_pin_num == 33) {
-		CORE_PIN33_CONFIG = PORT_PCR_MUX(5)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
-	} else if (scl_pin_num == 7) {
-		CORE_PIN7_CONFIG = PORT_PCR_MUX(7)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
-	} else if (scl_pin_num == 47) {
-		CORE_PIN47_CONFIG = PORT_PCR_MUX(2)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
-#endif	
+    
+}
+
+void TwoWire::end() {
+	if (_pwires) {
+		free((void*)_pwires);
+		_pwires = NULL;
 	}
-	setClock(100000);
-	I2C0_C2 = I2C_C2_HDRS;
-	I2C0_C1 = I2C_C1_IICEN;
-	//pinMode(3, OUTPUT);
-	//pinMode(4, OUTPUT);
 }
 
 void TwoWire::setClock(uint32_t frequency)
 {
-	if (!(SIM_SCGC4 & SIM_SCGC4_I2C0)) return;
+	if (!checkSIM_SCG()) {
+		return;
+	}
+KINETIS_I2C_t  *kinetisk_pi2c = kinetisk_i2c();
 
 #if F_BUS == 120000000
 	if (frequency < 400000) {
-		I2C0_F = I2C_F_DIV1152; // 104 kHz
+		kinetisk_pi2c->F = I2C_F_DIV1152; // 104 kHz
 	} else if (frequency < 1000000) {
-		I2C0_F = I2C_F_DIV288; // 416 kHz
+		kinetisk_pi2c->F = I2C_F_DIV288; // 416 kHz
 	} else {
-		I2C0_F = I2C_F_DIV128; // 0.94 MHz
+		kinetisk_pi2c->F = I2C_F_DIV128; // 0.94 MHz
 	}
-	I2C0_FLT = 4;
+	kinetisk_pi2c->FLT = 4;
 #elif F_BUS == 108000000
 	if (frequency < 400000) {
-		I2C0_F = I2C_F_DIV1024; // 105 kHz
+		kinetisk_pi2c->F = I2C_F_DIV1024; // 105 kHz
 	} else if (frequency < 1000000) {
-		I2C0_F = I2C_F_DIV256; //  422 kHz
+		kinetisk_pi2c->F = I2C_F_DIV256; //  422 kHz
 	} else {
-		I2C0_F = I2C_F_DIV112; // 0.96 MHz
+		kinetisk_pi2c->F = I2C_F_DIV112; // 0.96 MHz
 	}
-	I2C0_FLT = 4;
+	kinetisk_pi2c->FLT = 4;
 #elif F_BUS == 96000000
 	if (frequency < 400000) {
-		I2C0_F = I2C_F_DIV960; // 100 kHz
+		kinetisk_pi2c->F = I2C_F_DIV960; // 100 kHz
 	} else if (frequency < 1000000) {
-		I2C0_F = I2C_F_DIV240; // 400 kHz
+		kinetisk_pi2c->F = I2C_F_DIV240; // 400 kHz
 	} else {
-		I2C0_F = I2C_F_DIV96; // 1.0 MHz
+		kinetisk_pi2c->F = I2C_F_DIV96; // 1.0 MHz
 	}
-	I2C0_FLT = 4;
+	kinetisk_pi2c->FLT = 4;
 #elif F_BUS == 90000000
 	if (frequency < 400000) {
-		I2C0_F = I2C_F_DIV896; // 100 kHz
+		kinetisk_pi2c->F = I2C_F_DIV896; // 100 kHz
 	} else if (frequency < 1000000) {
-		I2C0_F = I2C_F_DIV224; // 402 kHz
+		kinetisk_pi2c->F = I2C_F_DIV224; // 402 kHz
 	} else {
-		I2C0_F = I2C_F_DIV88; // 1.02 MHz
+		kinetisk_pi2c->F = I2C_F_DIV88; // 1.02 MHz
 	}
-	I2C0_FLT = 4;
+	kinetisk_pi2c->FLT = 4;
 #elif F_BUS == 80000000
 	if (frequency < 400000) {
-		I2C0_F = I2C_F_DIV768; // 104 kHz
+		kinetisk_pi2c->F = I2C_F_DIV768; // 104 kHz
 	} else if (frequency < 1000000) {
-		I2C0_F = I2C_F_DIV192; // 416 kHz
+		kinetisk_pi2c->F = I2C_F_DIV192; // 416 kHz
 	} else {
-		I2C0_F = I2C_F_DIV80; // 1.0 MHz
+		kinetisk_pi2c->F = I2C_F_DIV80; // 1.0 MHz
 	}
-	I2C0_FLT = 4;
+	kinetisk_pi2c->FLT = 4;
 #elif F_BUS == 72000000
 	if (frequency < 400000) {
-		I2C0_F = I2C_F_DIV640; // 112 kHz
+		kinetisk_pi2c->F = I2C_F_DIV640; // 112 kHz
 	} else if (frequency < 1000000) {
-		I2C0_F = I2C_F_DIV192; // 375 kHz
+		kinetisk_pi2c->F = I2C_F_DIV192; // 375 kHz
 	} else {
-		I2C0_F = I2C_F_DIV72; // 1.0 MHz
+		kinetisk_pi2c->F = I2C_F_DIV72; // 1.0 MHz
 	}
-	I2C0_FLT = 4;
+	kinetisk_pi2c->FLT = 4;
 #elif F_BUS == 64000000
 	if (frequency < 400000) {
-		I2C0_F = I2C_F_DIV640; // 100 kHz
+		kinetisk_pi2c->F = I2C_F_DIV640; // 100 kHz
 	} else if (frequency < 1000000) {
-		I2C0_F = I2C_F_DIV160; // 400 kHz
+		kinetisk_pi2c->F = I2C_F_DIV160; // 400 kHz
 	} else {
-		I2C0_F = I2C_F_DIV64; // 1.0 MHz
+		kinetisk_pi2c->F = I2C_F_DIV64; // 1.0 MHz
 	}
-	I2C0_FLT = 4;
+	kinetisk_pi2c->FLT = 4;
 #elif F_BUS == 60000000
 	if (frequency < 400000) {
-		I2C0_F = 0x2C;	// 104 kHz
+		kinetisk_pi2c->F = 0x2C;	// 104 kHz
 	} else if (frequency < 1000000) {
-		I2C0_F = 0x1C; // 416 kHz
+		kinetisk_pi2c->F = 0x1C; // 416 kHz
 	} else {
-		I2C0_F = 0x12; // 938 kHz
+		kinetisk_pi2c->F = 0x12; // 938 kHz
 	}
-	I2C0_FLT = 4;
+	kinetisk_pi2c->FLT = 4;
 #elif F_BUS == 56000000
 	if (frequency < 400000) {
-		I2C0_F = 0x2B;	// 109 kHz
+		kinetisk_pi2c->F = 0x2B;	// 109 kHz
 	} else if (frequency < 1000000) {
-		I2C0_F = 0x1C; // 389 kHz
+		kinetisk_pi2c->F = 0x1C; // 389 kHz
 	} else {
-		I2C0_F = 0x0E; // 1 MHz
+		kinetisk_pi2c->F = 0x0E; // 1 MHz
 	}
-	I2C0_FLT = 4;
+	kinetisk_pi2c->FLT = 4;
 #elif F_BUS == 54000000
 	if (frequency < 400000) {
-		I2C0_F = I2C_F_DIV512;	// 105 kHz
+		kinetisk_pi2c->F = I2C_F_DIV512;	// 105 kHz
 	} else if (frequency < 1000000) {
-		I2C0_F = I2C_F_DIV128; // 422 kHz
+		kinetisk_pi2c->F = I2C_F_DIV128; // 422 kHz
 	} else {
-		I2C0_F = I2C_F_DIV56; // 0.96 MHz
+		kinetisk_pi2c->F = I2C_F_DIV56; // 0.96 MHz
 	}
-	I2C0_FLT = 4;
+	kinetisk_pi2c->FLT = 4;
 #elif F_BUS == 48000000
 	if (frequency < 400000) {
-		I2C0_F = 0x27;	// 100 kHz
+		kinetisk_pi2c->F = 0x27;	// 100 kHz
 	} else if (frequency < 1000000) {
-		I2C0_F = 0x1A; // 400 kHz
+		kinetisk_pi2c->F = 0x1A; // 400 kHz
 	} else {
-		I2C0_F = 0x0D; // 1 MHz
+		kinetisk_pi2c->F = 0x0D; // 1 MHz
 	}
-	I2C0_FLT = 4;
+	kinetisk_pi2c->FLT = 4;
 #elif F_BUS == 40000000
 	if (frequency < 400000) {
-		I2C0_F = 0x29;	// 104 kHz
+		kinetisk_pi2c->F = 0x29;	// 104 kHz
 	} else if (frequency < 1000000) {
-		I2C0_F = 0x19; // 416 kHz
+		kinetisk_pi2c->F = 0x19; // 416 kHz
 	} else {
-		I2C0_F = 0x0B; // 1 MHz
+		kinetisk_pi2c->F = 0x0B; // 1 MHz
 	}
-	I2C0_FLT = 3;
+	kinetisk_pi2c->FLT = 3;
 #elif F_BUS == 36000000
 	if (frequency < 400000) {
-		I2C0_F = 0x28;	// 113 kHz
+		kinetisk_pi2c->F = 0x28;	// 113 kHz
 	} else if (frequency < 1000000) {
-		I2C0_F = 0x19; // 375 kHz
+		kinetisk_pi2c->F = 0x19; // 375 kHz
 	} else {
-		I2C0_F = 0x0A; // 1 MHz
+		kinetisk_pi2c->F = 0x0A; // 1 MHz
 	}
-	I2C0_FLT = 3;
+	kinetisk_pi2c->FLT = 3;
 #elif F_BUS == 24000000
 	if (frequency < 400000) {
-		I2C0_F = 0x1F; // 100 kHz
+		kinetisk_pi2c->F = 0x1F; // 100 kHz
 	} else if (frequency < 1000000) {
-		I2C0_F = 0x12; // 375 kHz
+		kinetisk_pi2c->F = 0x12; // 375 kHz
 	} else {
-		I2C0_F = 0x02; // 1 MHz
+		kinetisk_pi2c->F = 0x02; // 1 MHz
 	}
-	I2C0_FLT = 2;
+	kinetisk_pi2c->FLT = 2;
 #elif F_BUS == 16000000
 	if (frequency < 400000) {
-		I2C0_F = 0x20; // 100 kHz
+		kinetisk_pi2c->F = 0x20; // 100 kHz
 	} else if (frequency < 1000000) {
-		I2C0_F = 0x07; // 400 kHz
+		kinetisk_pi2c->F = 0x07; // 400 kHz
 	} else {
-		I2C0_F = 0x00; // 800 MHz
+		kinetisk_pi2c->F = 0x00; // 800 MHz
 	}
-	I2C0_FLT = 1;
+	kinetisk_pi2c->FLT = 1;
 #elif F_BUS == 8000000
 	if (frequency < 400000) {
-		I2C0_F = 0x14; // 100 kHz
+		kinetisk_pi2c->F = 0x14; // 100 kHz
 	} else {
-		I2C0_F = 0x00; // 400 kHz
+		kinetisk_pi2c->F = 0x00; // 400 kHz
 	}
-	I2C0_FLT = 1;
+	kinetisk_pi2c->FLT = 1;
 #elif F_BUS == 4000000
 	if (frequency < 400000) {
-		I2C0_F = 0x07; // 100 kHz
+		kinetisk_pi2c->F = 0x07; // 100 kHz
 	} else {
-		I2C0_F = 0x00; // 200 kHz
+		kinetisk_pi2c->F = 0x00; // 200 kHz
 	}
-	I2C0_FLT = 1;
+	kinetisk_pi2c->FLT = 1;
 #elif F_BUS == 2000000
-	I2C0_F = 0x00; // 100 kHz
-	I2C0_FLT = 1;
+	kinetisk_pi2c->F = 0x00; // 100 kHz
+	kinetisk_pi2c->FLT = 1;
 #else
 #error "F_BUS must be 120, 108, 96, 9, 80, 72, 64, 60, 56, 54, 48, 40, 36, 24, 16, 8, 4 or 2 MHz"
 #endif
 }
 
-void TwoWire::setSDA(uint8_t pin)
+
+
+uint8_t TwoWire::isr(WIRE_STRUCT *pwires, KINETIS_I2C_t * kinetisk_pi2c)
 {
-	if (pin == sda_pin_num) return;
-	if ((SIM_SCGC4 & SIM_SCGC4_I2C0)) {
-		if (sda_pin_num == 18) {
-			CORE_PIN18_CONFIG = 0;
-		} else if (sda_pin_num == 17) {
-			CORE_PIN17_CONFIG = 0;
-#if defined(__MK64FX512__) || defined(__MK66FX1M0__)
-		} else if (sda_pin_num == 34) {
-			CORE_PIN34_CONFIG = 0;
-		} else if (sda_pin_num == 8) {
-			CORE_PIN8_CONFIG = 0;
-		} else if (sda_pin_num == 48) {
-			CORE_PIN48_CONFIG = 0;
-#endif	
-		}
-
-		if (pin == 18) {
-			CORE_PIN18_CONFIG = PORT_PCR_MUX(2)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
-		} else if (pin == 17) {
-			CORE_PIN17_CONFIG = PORT_PCR_MUX(2)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
-#if defined(__MK64FX512__) || defined(__MK66FX1M0__)
-		} else if (pin == 34) {
-			CORE_PIN34_CONFIG = PORT_PCR_MUX(5)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
-		} else if (pin == 8) {
-			CORE_PIN8_CONFIG = PORT_PCR_MUX(7)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
-		} else if (pin == 48) {
-			CORE_PIN48_CONFIG = PORT_PCR_MUX(2)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
-#endif	
-		}
-	}
-	sda_pin_num = pin;
-}
-
-void TwoWire::setSCL(uint8_t pin)
-{
-	if (pin == scl_pin_num) return;
-	if ((SIM_SCGC4 & SIM_SCGC4_I2C0)) {
-		if (scl_pin_num == 19) {
-			CORE_PIN19_CONFIG = 0;
-		} else if (scl_pin_num == 16) {
-			CORE_PIN16_CONFIG = 0;
-#if defined(__MK64FX512__) || defined(__MK66FX1M0__)
-		} else if (scl_pin_num == 33) {
-			CORE_PIN33_CONFIG = 0;
-		} else if (scl_pin_num == 7) {
-			CORE_PIN7_CONFIG = 0;
-		} else if (scl_pin_num == 47) {
-			CORE_PIN47_CONFIG = 0;
-#endif	
-		}
-
-		if (pin == 19) {
-			CORE_PIN19_CONFIG = PORT_PCR_MUX(2)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
-		} else if (pin == 16) {
-			CORE_PIN16_CONFIG = PORT_PCR_MUX(2)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
-#if defined(__MK64FX512__) || defined(__MK66FX1M0__)
-		} else if (pin == 33) {
-			CORE_PIN33_CONFIG = PORT_PCR_MUX(5)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
-		} else if (pin == 7) {
-			CORE_PIN7_CONFIG = PORT_PCR_MUX(7)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
-		} else if (pin == 47) {
-			CORE_PIN47_CONFIG = PORT_PCR_MUX(2)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
-#endif	
-		}
-	}
-	scl_pin_num = pin;
-}
-
-void TwoWire::begin(uint8_t address)
-{
-	begin();
-	I2C0_A1 = address << 1;
-	slave_mode = 1;
-	I2C0_C1 = I2C_C1_IICEN | I2C_C1_IICIE;
-	NVIC_ENABLE_IRQ(IRQ_I2C0);
-}
-
-void TwoWire::end()
-{
-	if (!(SIM_SCGC4 & SIM_SCGC4_I2C0)) return;
-	NVIC_DISABLE_IRQ(IRQ_I2C0);
-	I2C0_C1 = 0;
-	if (sda_pin_num == 18) {
-		CORE_PIN18_CONFIG = 0;
-	} else if (sda_pin_num == 17) {
-		CORE_PIN17_CONFIG = 0;
-#if defined(__MK64FX512__) || defined(__MK66FX1M0__)
-	} else if (sda_pin_num == 34) {
-		CORE_PIN34_CONFIG = 0;
-	} else if (sda_pin_num == 8) {
-		CORE_PIN8_CONFIG = 0;
-	} else if (sda_pin_num == 48) {
-		CORE_PIN48_CONFIG = 0;
-#endif	
-	}
-	if (scl_pin_num == 19) {
-		CORE_PIN19_CONFIG = 0;
-	} else if (scl_pin_num == 16) {
-		CORE_PIN16_CONFIG = 0;
-#if defined(__MK64FX512__) || defined(__MK66FX1M0__)
-	} else if (scl_pin_num == 33) {
-		CORE_PIN33_CONFIG = 0;
-	} else if (scl_pin_num == 7) {
-		CORE_PIN7_CONFIG = 0;
-	} else if (scl_pin_num == 47) {
-		CORE_PIN47_CONFIG = 0;
-#endif	
-	}
-	SIM_SCGC4 &= ~SIM_SCGC4_I2C0; // TODO: use bitband
-}
-
-void i2c0_isr(void)
-{
+	uint8_t retval = 0;
 	uint8_t status, c1, data;
-	static uint8_t receiving=0;
 
-	status = I2C0_S;
+	status = kinetisk_pi2c->S;
 	//serial_print(".");
 	if (status & I2C_S_ARBL) {
 		// Arbitration Lost
-		I2C0_S = I2C_S_ARBL;
+		kinetisk_pi2c->S = I2C_S_ARBL;
 		//serial_print("a");
-		if (receiving && TwoWire::rxBufferLength > 0) {
+		if (pwires->receiving && pwires->rxBufferLength > 0) {
 			// TODO: does this detect the STOP condition in slave receive mode?
 
 
 		}
-		if (!(status & I2C_S_IAAS)) return;
+		if (!(status & I2C_S_IAAS)) return 0;
 	}
 	if (status & I2C_S_IAAS) {
 		//serial_print("\n");
@@ -396,150 +262,134 @@ void i2c0_isr(void)
 		if (status & I2C_S_SRW) {
 			//serial_print("T");
 			// Begin Slave Transmit
-			receiving = 0;
-			TwoWire::txBufferLength = 0;
-			if (TwoWire::user_onRequest != NULL) {
-				TwoWire::user_onRequest();
+			pwires->receiving = 0;
+			pwires->txBufferLength = 0;
+			if (pwires->user_onRequest != NULL) {
+				pwires->user_onRequest();
 			}
-			if (TwoWire::txBufferLength == 0) {
+			if (pwires->txBufferLength == 0) {
 				// is this correct, transmitting a single zero
 				// when we should send nothing?  Arduino's AVR
 				// implementation does this, but is it ok?
-				TwoWire::txBufferLength = 1;
-				TwoWire::txBuffer[0] = 0;
+				pwires->txBufferLength = 1;
+				pwires->txBuffer[0] = 0;
 			}
-			I2C0_C1 = I2C_C1_IICEN | I2C_C1_IICIE | I2C_C1_TX;
-			I2C0_D = TwoWire::txBuffer[0];
-			TwoWire::txBufferIndex = 1;
+			kinetisk_pi2c->C1 = I2C_C1_IICEN | I2C_C1_IICIE | I2C_C1_TX;
+			kinetisk_pi2c->D = pwires->txBuffer[0];
+			pwires->txBufferIndex = 1;
 		} else {
 			// Begin Slave Receive
 			//serial_print("R");
-			receiving = 1;
-			TwoWire::rxBufferLength = 0;
-			I2C0_C1 = I2C_C1_IICEN | I2C_C1_IICIE;
-			data = I2C0_D;
+			pwires->receiving = 1;
+			pwires->rxBufferLength = 0;
+			kinetisk_pi2c->C1 = I2C_C1_IICEN | I2C_C1_IICIE;
+			data = kinetisk_pi2c->D;
 		}
-		I2C0_S = I2C_S_IICIF;
-		return;
+		kinetisk_pi2c->S = I2C_S_IICIF;
+		return 0;
 	}
 	#if defined(KINETISL)
-	c1 = I2C0_FLT;
+	c1 = kinetisk_pi2c->FLT;
 	if ((c1 & I2C_FLT_STOPF) && (c1 & I2C_FLT_STOPIE)) {
-		I2C0_FLT = c1 & ~I2C_FLT_STOPIE;
-		if (TwoWire::user_onReceive != NULL) {
-			TwoWire::rxBufferIndex = 0;
-			TwoWire::user_onReceive(TwoWire::rxBufferLength);
+		kinetisk_pi2c->FLT = c1 & ~I2C_FLT_STOPIE;
+		if (pwires->user_onReceive != NULL) {
+			pwires->rxBufferIndex = 0;
+			pwires->user_onReceive(pwires->rxBufferLength);
 		}
 	}
 	#endif
-	c1 = I2C0_C1;
+	c1 = kinetisk_pi2c->C1;
 	if (c1 & I2C_C1_TX) {
 		// Continue Slave Transmit
 		//serial_print("t");
 		if ((status & I2C_S_RXAK) == 0) {
 			//serial_print(".");
 			// Master ACK'd previous byte
-			if (TwoWire::txBufferIndex < TwoWire::txBufferLength) {
-				I2C0_D = TwoWire::txBuffer[TwoWire::txBufferIndex++];
+			if (pwires->txBufferIndex < pwires->txBufferLength) {
+				kinetisk_pi2c->D = pwires->txBuffer[pwires->txBufferIndex++];
 			} else {
-				I2C0_D = 0;
+				kinetisk_pi2c->D = 0;
 			}
-			I2C0_C1 = I2C_C1_IICEN | I2C_C1_IICIE | I2C_C1_TX;
+			kinetisk_pi2c->C1 = I2C_C1_IICEN | I2C_C1_IICIE | I2C_C1_TX;
 		} else {
 			//serial_print("*");
 			// Master did not ACK previous byte
-			I2C0_C1 = I2C_C1_IICEN | I2C_C1_IICIE;
-			data = I2C0_D;
+			kinetisk_pi2c->C1 = I2C_C1_IICEN | I2C_C1_IICIE;
+			data = kinetisk_pi2c->D;
 		}
 	} else {
 		// Continue Slave Receive
-		irqcount = 0;
+		pwires->irqcount = 0;
 		#if defined(KINETISK)
-		attachInterrupt(18, TwoWire::sda_rising_isr, RISING);
+		retval = 1;
 		#elif defined(KINETISL)
-		I2C0_FLT |= I2C_FLT_STOPIE;
+		kinetisk_pi2c->FLT |= I2C_FLT_STOPIE;
 		#endif
 		//digitalWriteFast(4, HIGH);
-		data = I2C0_D;
+		data = kinetisk_pi2c->D;
 		//serial_phex(data);
-		if (TwoWire::rxBufferLength < BUFFER_LENGTH && receiving) {
-			TwoWire::rxBuffer[TwoWire::rxBufferLength++] = data;
+		if (pwires->rxBufferLength < BUFFER_LENGTH && pwires->receiving) {
+			pwires->rxBuffer[pwires->rxBufferLength++] = data;
 		}
 		//digitalWriteFast(4, LOW);
 	}
-	I2C0_S = I2C_S_IICIF;
-}
-
-// Detects the stop condition that terminates a slave receive transfer.
-// Sadly, the I2C in Kinetis K series lacks the stop detect interrupt
-// This pin change interrupt hack is needed to detect the stop condition
-void TwoWire::sda_rising_isr(void)
-{
-	//digitalWrite(3, HIGH);
-	if (!(I2C0_S & I2C_S_BUSY)) {
-		detachInterrupt(18);
-		if (user_onReceive != NULL) {
-			rxBufferIndex = 0;
-			user_onReceive(rxBufferLength);
-		}
-		//delayMicroseconds(100);
-	} else {
-		if (++irqcount >= 2 || !slave_mode) {
-			detachInterrupt(18);
-		}
-	}
-	//digitalWrite(3, LOW);
+	kinetisk_pi2c->S = I2C_S_IICIF;
+	return retval;
 }
 
 
 // Chapter 44: Inter-Integrated Circuit (I2C) - Page 1012
-//  I2C0_A1      // I2C Address Register 1
-//  I2C0_F       // I2C Frequency Divider register
-//  I2C0_C1      // I2C Control Register 1
-//  I2C0_S       // I2C Status register
-//  I2C0_D       // I2C Data I/O register
-//  I2C0_C2      // I2C Control Register 2
-//  I2C0_FLT     // I2C Programmable Input Glitch Filter register
+//  kinetisk_pi2c->A1      // I2C Address Register 1
+//  I2C1_F       // I2C Frequency Divider register
+//  I2C1_C1      // I2C Control Register 1
+//  I2C1_S       // I2C Status register
+//  I2C1_D       // I2C Data I/O register
+//  I2C1_C2      // I2C Control Register 2
+//  I2C1_FLT     // I2C Programmable Input Glitch Filter register
 
-static uint8_t i2c_status(void)
+uint8_t TwoWire::i2c_status(KINETIS_I2C_t  *kinetisk_pi2c)
 {
+#if 0	
 	static uint32_t p=0xFFFF;
-	uint32_t s = I2C0_S;
+	uint32_t s = kinetisk_pi2c->S;
 	if (s != p) {
 		//Serial.printf("(%02X)", s);
 		p = s;
 	}
 	return s;
+#else
+	return kinetisk_pi2c->S;
+#endif	
 }
 
-static void i2c_wait(void)
+void TwoWire::i2c_wait(KINETIS_I2C_t  *kinetisk_pi2c)
 {
 #if 0
-	while (!(I2C0_S & I2C_S_IICIF)) ; // wait
-	I2C0_S = I2C_S_IICIF;
+	while (!(kinetisk_pi2c->S & I2C_S_IICIF)) ; // wait
+	kinetisk_pi2c->S = I2C_S_IICIF;
 #endif
 	//Serial.write('^');
 	while (1) {
-		if ((i2c_status() & I2C_S_IICIF)) break;
+		if ((i2c_status(kinetisk_pi2c) & I2C_S_IICIF)) break;
 	}
-	I2C0_S = I2C_S_IICIF;
+	kinetisk_pi2c->S = I2C_S_IICIF;
 }
 
 void TwoWire::beginTransmission(uint8_t address)
 {
-	txBuffer[0] = (address << 1);
-	transmitting = 1;
-	txBufferLength = 1;
+	_pwires->txBuffer[0] = (address << 1);
+	_pwires->transmitting = 1;
+	_pwires->txBufferLength = 1;
 }
 
 size_t TwoWire::write(uint8_t data)
 {
-	if (transmitting || slave_mode) {
-		if (txBufferLength >= BUFFER_LENGTH+1) {
+	if (_pwires->transmitting || _pwires->slave_mode) {
+		if (_pwires->txBufferLength >= BUFFER_LENGTH+1) {
 			setWriteError();
 			return 0;
 		}
-		txBuffer[txBufferLength++] = data;
+		_pwires->txBuffer[_pwires->txBufferLength++] = data;
 		return 1;
 	}
 	return 0;
@@ -547,14 +397,14 @@ size_t TwoWire::write(uint8_t data)
 
 size_t TwoWire::write(const uint8_t *data, size_t quantity)
 {
-	if (transmitting || slave_mode) {
-		size_t avail = BUFFER_LENGTH+1 - txBufferLength;
+	if (_pwires->transmitting || _pwires->slave_mode) {
+		size_t avail = BUFFER_LENGTH+1 - _pwires->txBufferLength;
 		if (quantity > avail) {
 			quantity = avail;
 			setWriteError();
 		}
-		memcpy(txBuffer + txBufferLength, data, quantity);
-		txBufferLength += quantity;
+		memcpy(_pwires->txBuffer + _pwires->txBufferLength, data, quantity);
+		_pwires->txBufferLength += quantity;
 		return quantity;
 	}
 	return 0;
@@ -570,58 +420,61 @@ uint8_t TwoWire::endTransmission(uint8_t sendStop)
 	uint8_t i, status, ret=0;
 
 	// clear the status flags
-	I2C0_S = I2C_S_IICIF | I2C_S_ARBL;
+
+	KINETIS_I2C_t  *kinetisk_pi2c = kinetisk_i2c();
+	
+	kinetisk_pi2c->S = I2C_S_IICIF | I2C_S_ARBL;
 	// now take control of the bus...
-	if (I2C0_C1 & I2C_C1_MST) {
+	if (kinetisk_pi2c->C1 & I2C_C1_MST) {
 		// we are already the bus master, so send a repeated start
 		//Serial.print("rstart:");
-		I2C0_C1 = I2C_C1_IICEN | I2C_C1_MST | I2C_C1_RSTA | I2C_C1_TX;
+		kinetisk_pi2c->C1 = I2C_C1_IICEN | I2C_C1_MST | I2C_C1_RSTA | I2C_C1_TX;
 	} else {
 		// we are not currently the bus master, so wait for bus ready
 		//Serial.print("busy:");
 		uint32_t wait_begin = millis();
-		while (i2c_status() & I2C_S_BUSY) {
+		while (i2c_status(kinetisk_pi2c) & I2C_S_BUSY) {
 			//Serial.write('.') ;
 			if (millis() - wait_begin > 15) {
 				// bus stuck busy too long
-				I2C0_C1 = 0;
-				I2C0_C1 = I2C_C1_IICEN;
+				kinetisk_pi2c->C1 = 0;
+				kinetisk_pi2c->C1 = I2C_C1_IICEN;
 				//Serial.println("abort");
 				return 4;
 			}
 		}
 		// become the bus master in transmit mode (send start)
-		slave_mode = 0;
-		I2C0_C1 = I2C_C1_IICEN | I2C_C1_MST | I2C_C1_TX;
+		_pwires->slave_mode = 0;
+		kinetisk_pi2c->C1 = I2C_C1_IICEN | I2C_C1_MST | I2C_C1_TX;
 	}
 	// wait until start condition establishes control of the bus
 	while (1) {
-		status = i2c_status();
+		status = i2c_status(kinetisk_pi2c);
 		if ((status & I2C_S_BUSY)) break;
 	}
 	// transmit the address and data
-	for (i=0; i < txBufferLength; i++) {
-		I2C0_D = txBuffer[i];
+	for (i=0; i < _pwires->txBufferLength; i++) {
+		kinetisk_pi2c->D = _pwires->txBuffer[i];
 		//Serial.write('^');
 		while (1) {
-			status = i2c_status();
+			status = i2c_status(kinetisk_pi2c);
 			if ((status & I2C_S_IICIF)) break;
 			if (!(status & I2C_S_BUSY)) break;
 		}
-		I2C0_S = I2C_S_IICIF;
+		kinetisk_pi2c->S = I2C_S_IICIF;
 		//Serial.write('$');
-		status = i2c_status();
+		status = i2c_status(kinetisk_pi2c);
 		if ((status & I2C_S_ARBL)) {
 			// we lost bus arbitration to another master
 			// TODO: what is the proper thing to do here??
-			//Serial.printf(" c1=%02X ", I2C0_C1);
-			I2C0_C1 = I2C_C1_IICEN;
+			//Serial.printf(" c1=%02X ", kinetisk_pi2c->C1);
+			kinetisk_pi2c->C1 = I2C_C1_IICEN;
 			ret = 4; // 4:other error
 			break;
 		}
 		if (!(status & I2C_S_BUSY)) {
 			// suddenly lost control of the bus!
-			I2C0_C1 = I2C_C1_IICEN;
+			kinetisk_pi2c->C1 = I2C_C1_IICEN;
 			ret = 4; // 4:other error
 			break;
 		}
@@ -638,10 +491,10 @@ uint8_t TwoWire::endTransmission(uint8_t sendStop)
 	}
 	if (sendStop) {
 		// send the stop condition
-		I2C0_C1 = I2C_C1_IICEN;
+		kinetisk_pi2c->C1 = I2C_C1_IICEN;
 		// TODO: do we wait for this somehow?
 	}
-	transmitting = 0;
+	_pwires->transmitting = 0;
 	//Serial.print(" ret=");
 	//Serial.println(ret);
 	return ret;
@@ -652,88 +505,111 @@ uint8_t TwoWire::requestFrom(uint8_t address, uint8_t length, uint8_t sendStop)
 {
 	uint8_t tmp __attribute__((unused));
 	uint8_t status, count=0;
+	
+	KINETIS_I2C_t  *kinetisk_pi2c = kinetisk_i2c();
 
-	rxBufferIndex = 0;
-	rxBufferLength = 0;
-	//serial_print("requestFrom\n");
+	_pwires->rxBufferIndex = 0;
+	_pwires->rxBufferLength = 0;
+
+	// BUGBUG: see if I can loop a little 
+	uint8_t delay_count = 0xff;
+	while (delay_count-- && (i2c_status(kinetisk_pi2c) & I2C_S_BUSY)) ;
+
 	// clear the status flags
-	I2C0_S = I2C_S_IICIF | I2C_S_ARBL;
+	kinetisk_pi2c->S = I2C_S_IICIF | I2C_S_ARBL;
 	// now take control of the bus...
-	if (I2C0_C1 & I2C_C1_MST) {
+	if (kinetisk_pi2c->C1 & I2C_C1_MST) {
 		// we are already the bus master, so send a repeated start
-		I2C0_C1 = I2C_C1_IICEN | I2C_C1_MST | I2C_C1_RSTA | I2C_C1_TX;
+		kinetisk_pi2c->C1 = I2C_C1_IICEN | I2C_C1_MST | I2C_C1_RSTA | I2C_C1_TX;
 	} else {
 		// we are not currently the bus master, so wait for bus ready
-		while (i2c_status() & I2C_S_BUSY) ;
+		while (i2c_status(kinetisk_pi2c) & I2C_S_BUSY) ;
 		// become the bus master in transmit mode (send start)
-		slave_mode = 0;
-		I2C0_C1 = I2C_C1_IICEN | I2C_C1_MST | I2C_C1_TX;
+		_pwires->slave_mode = 0;
+		kinetisk_pi2c->C1 = I2C_C1_IICEN | I2C_C1_MST | I2C_C1_TX;
 	}
 	// send the address
-	I2C0_D = (address << 1) | 1;
-	i2c_wait();
-	status = i2c_status();
+	kinetisk_pi2c->D = (address << 1) | 1;
+	i2c_wait(kinetisk_pi2c);
+	status = i2c_status(kinetisk_pi2c);
 	if ((status & I2C_S_RXAK) || (status & I2C_S_ARBL)) {
 		// the slave device did not acknowledge
 		// or we lost bus arbitration to another master
-		I2C0_C1 = I2C_C1_IICEN;
+		kinetisk_pi2c->C1 = I2C_C1_IICEN;
 		return 0;
 	}
 	if (length == 0) {
 		// TODO: does anybody really do zero length reads?
 		// if so, does this code really work?
-		I2C0_C1 = I2C_C1_IICEN | (sendStop ? 0 : I2C_C1_MST);
+		kinetisk_pi2c->C1 = I2C_C1_IICEN | (sendStop ? 0 : I2C_C1_MST);
 		return 0;
 	} else if (length == 1) {
-		I2C0_C1 = I2C_C1_IICEN | I2C_C1_MST | I2C_C1_TXAK;
+		kinetisk_pi2c->C1 = I2C_C1_IICEN | I2C_C1_MST | I2C_C1_TXAK;
 	} else {
-		I2C0_C1 = I2C_C1_IICEN | I2C_C1_MST;
+		kinetisk_pi2c->C1 = I2C_C1_IICEN | I2C_C1_MST;
 	}
-	tmp = I2C0_D; // initiate the first receive
+	tmp = kinetisk_pi2c->D; // initiate the first receive
 	while (length > 1) {
-		i2c_wait();
+		i2c_wait(kinetisk_pi2c);
 		length--;
-		if (length == 1) I2C0_C1 = I2C_C1_IICEN | I2C_C1_MST | I2C_C1_TXAK;
+		if (length == 1) kinetisk_pi2c->C1 = I2C_C1_IICEN | I2C_C1_MST | I2C_C1_TXAK;
 		if (count < BUFFER_LENGTH) {
-			rxBuffer[count++] = I2C0_D;
+			_pwires->rxBuffer[count++] = kinetisk_pi2c->D;
 		} else {
-			tmp = I2C0_D;
+			tmp = kinetisk_pi2c->D;
 		}
 	}
-	i2c_wait();
-	I2C0_C1 = I2C_C1_IICEN | I2C_C1_MST | I2C_C1_TX;
+	i2c_wait(kinetisk_pi2c);
+	kinetisk_pi2c->C1 = I2C_C1_IICEN | I2C_C1_MST | I2C_C1_TX;
 	if (count < BUFFER_LENGTH) {
-		rxBuffer[count++] = I2C0_D;
+		_pwires->rxBuffer[count++] = kinetisk_pi2c->D;
 	} else {
-		tmp = I2C0_D;
+		tmp = kinetisk_pi2c->D;
 	}
-	if (sendStop) I2C0_C1 = I2C_C1_IICEN;
-	rxBufferLength = count;
+	if (sendStop) kinetisk_pi2c->C1 = I2C_C1_IICEN;
+	_pwires->rxBufferLength = count;
 	return count;
 }
 
 int TwoWire::available(void)
 {
-	return rxBufferLength - rxBufferIndex;
+	return _pwires->rxBufferLength - _pwires->rxBufferIndex;
 }
 
 int TwoWire::read(void)
 {
-	if (rxBufferIndex >= rxBufferLength) return -1;
-	return rxBuffer[rxBufferIndex++];
+	if (_pwires->rxBufferIndex >= _pwires->rxBufferLength) return -1;
+	return _pwires->rxBuffer[_pwires->rxBufferIndex++];
 }
 
 int TwoWire::peek(void)
 {
-	if (rxBufferIndex >= rxBufferLength) return -1;
-	return rxBuffer[rxBufferIndex];
+	if (_pwires->rxBufferIndex >= _pwires->rxBufferLength) return -1;
+	return _pwires->rxBuffer[_pwires->rxBufferIndex];
 }
 
 
-
-
-
 // alternate function prototypes
+void TwoWire::send(uint8_t *s, uint8_t n)   
+{
+	write(s, n); 
+}
+void TwoWire::send(int n)
+{ 
+	write((uint8_t)n); 
+}
+
+void TwoWire::send(char *s)
+{ 
+	write(s); 
+}
+
+uint8_t TwoWire::receive(void) 
+{
+    int c = read();
+    if (c < 0) return 0;
+    return c;
+}
 
 uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity)
 {
@@ -767,318 +643,14 @@ void TwoWire::begin(int address)
 
 void TwoWire::onReceive( void (*function)(int) )
 {
-	user_onReceive = function;
+	checkAndAllocateStruct();
+	_pwires->user_onReceive = function;
 }
 
 void TwoWire::onRequest( void (*function)(void) )
 {
-	user_onRequest = function;
+	checkAndAllocateStruct();
+	_pwires->user_onRequest = function;
 }
 
-//TwoWire Wire = TwoWire();
-TwoWire Wire;
-
-
-#endif // __MK20DX128__ || __MK20DX256__
-
-
-
-#if defined(__AVR__)
-
-extern "C" {
-  #include <stdlib.h>
-  #include <string.h>
-  #include <inttypes.h>
-  #include "twi.h"
-}
-
-
-// Initialize Class Variables //////////////////////////////////////////////////
-
-uint8_t TwoWire::rxBuffer[BUFFER_LENGTH];
-uint8_t TwoWire::rxBufferIndex = 0;
-uint8_t TwoWire::rxBufferLength = 0;
-
-uint8_t TwoWire::txAddress = 0;
-uint8_t TwoWire::txBuffer[BUFFER_LENGTH];
-uint8_t TwoWire::txBufferIndex = 0;
-uint8_t TwoWire::txBufferLength = 0;
-
-uint8_t TwoWire::transmitting = 0;
-void (*TwoWire::user_onRequest)(void);
-void (*TwoWire::user_onReceive)(int);
-
-// Constructors ////////////////////////////////////////////////////////////////
-
-TwoWire::TwoWire()
-{
-}
-
-// Public Methods //////////////////////////////////////////////////////////////
-
-void TwoWire::begin(void)
-{
-  rxBufferIndex = 0;
-  rxBufferLength = 0;
-
-  txBufferIndex = 0;
-  txBufferLength = 0;
-
-  twi_init();
-}
-
-void TwoWire::begin(uint8_t address)
-{
-  twi_setAddress(address);
-  twi_attachSlaveTxEvent(onRequestService);
-  twi_attachSlaveRxEvent(onReceiveService);
-  begin();
-}
-
-void TwoWire::begin(int address)
-{
-  begin((uint8_t)address);
-}
-
-void TwoWire::end()
-{
-  TWCR &= ~(_BV(TWEN) | _BV(TWIE) | _BV(TWEA));
-  digitalWrite(SDA, 0);
-  digitalWrite(SCL, 0);
-}
-
-void TwoWire::setClock(uint32_t frequency)
-{
-  TWBR = ((F_CPU / frequency) - 16) / 2;
-}
-
-void TwoWire::setSDA(uint8_t pin)
-{
-}
-
-void TwoWire::setSCL(uint8_t pin)
-{
-}
-
-uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint8_t sendStop)
-{
-  // clamp to buffer length
-  if(quantity > BUFFER_LENGTH){
-    quantity = BUFFER_LENGTH;
-  }
-  // perform blocking read into buffer
-  uint8_t read = twi_readFrom(address, rxBuffer, quantity, sendStop);
-  // set rx buffer iterator vars
-  rxBufferIndex = 0;
-  rxBufferLength = read;
-
-  return read;
-}
-
-uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity)
-{
-  return requestFrom((uint8_t)address, (uint8_t)quantity, (uint8_t)true);
-}
-
-uint8_t TwoWire::requestFrom(int address, int quantity)
-{
-  return requestFrom((uint8_t)address, (uint8_t)quantity, (uint8_t)true);
-}
-
-uint8_t TwoWire::requestFrom(int address, int quantity, int sendStop)
-{
-  return requestFrom((uint8_t)address, (uint8_t)quantity, (uint8_t)sendStop);
-}
-
-void TwoWire::beginTransmission(uint8_t address)
-{
-  // indicate that we are transmitting
-  transmitting = 1;
-  // set address of targeted slave
-  txAddress = address;
-  // reset tx buffer iterator vars
-  txBufferIndex = 0;
-  txBufferLength = 0;
-}
-
-void TwoWire::beginTransmission(int address)
-{
-  beginTransmission((uint8_t)address);
-}
-
-//
-//	Originally, 'endTransmission' was an f(void) function.
-//	It has been modified to take one parameter indicating
-//	whether or not a STOP should be performed on the bus.
-//	Calling endTransmission(false) allows a sketch to 
-//	perform a repeated start. 
-//
-//	WARNING: Nothing in the library keeps track of whether
-//	the bus tenure has been properly ended with a STOP. It
-//	is very possible to leave the bus in a hung state if
-//	no call to endTransmission(true) is made. Some I2C
-//	devices will behave oddly if they do not see a STOP.
-//
-uint8_t TwoWire::endTransmission(uint8_t sendStop)
-{
-  // transmit buffer (blocking)
-  int8_t ret = twi_writeTo(txAddress, txBuffer, txBufferLength, 1, sendStop);
-  // reset tx buffer iterator vars
-  txBufferIndex = 0;
-  txBufferLength = 0;
-  // indicate that we are done transmitting
-  transmitting = 0;
-  return ret;
-}
-
-//	This provides backwards compatibility with the original
-//	definition, and expected behaviour, of endTransmission
-//
-uint8_t TwoWire::endTransmission(void)
-{
-  return endTransmission(true);
-}
-
-// must be called in:
-// slave tx event callback
-// or after beginTransmission(address)
-size_t TwoWire::write(uint8_t data)
-{
-  if(transmitting){
-  // in master transmitter mode
-    // don't bother if buffer is full
-    if(txBufferLength >= BUFFER_LENGTH){
-      setWriteError();
-      return 0;
-    }
-    // put byte in tx buffer
-    txBuffer[txBufferIndex] = data;
-    ++txBufferIndex;
-    // update amount in buffer   
-    txBufferLength = txBufferIndex;
-  }else{
-  // in slave send mode
-    // reply to master
-    twi_transmit(&data, 1);
-  }
-  return 1;
-}
-
-// must be called in:
-// slave tx event callback
-// or after beginTransmission(address)
-size_t TwoWire::write(const uint8_t *data, size_t quantity)
-{
-  if(transmitting){
-  // in master transmitter mode
-    for(size_t i = 0; i < quantity; ++i){
-      write(data[i]);
-    }
-  }else{
-  // in slave send mode
-    // reply to master
-    twi_transmit(data, quantity);
-  }
-  return quantity;
-}
-
-// must be called in:
-// slave rx event callback
-// or after requestFrom(address, numBytes)
-int TwoWire::available(void)
-{
-  return rxBufferLength - rxBufferIndex;
-}
-
-// must be called in:
-// slave rx event callback
-// or after requestFrom(address, numBytes)
-int TwoWire::read(void)
-{
-  int value = -1;
-  
-  // get each successive byte on each call
-  if(rxBufferIndex < rxBufferLength){
-    value = rxBuffer[rxBufferIndex];
-    ++rxBufferIndex;
-  }
-
-  return value;
-}
-
-// must be called in:
-// slave rx event callback
-// or after requestFrom(address, numBytes)
-int TwoWire::peek(void)
-{
-  int value = -1;
-  
-  if(rxBufferIndex < rxBufferLength){
-    value = rxBuffer[rxBufferIndex];
-  }
-
-  return value;
-}
-
-void TwoWire::flush(void)
-{
-  // XXX: to be implemented.
-}
-
-// behind the scenes function that is called when data is received
-void TwoWire::onReceiveService(uint8_t* inBytes, int numBytes)
-{
-  // don't bother if user hasn't registered a callback
-  if(!user_onReceive){
-    return;
-  }
-  // don't bother if rx buffer is in use by a master requestFrom() op
-  // i know this drops data, but it allows for slight stupidity
-  // meaning, they may not have read all the master requestFrom() data yet
-  if(rxBufferIndex < rxBufferLength){
-    return;
-  }
-  // copy twi rx buffer into local read buffer
-  // this enables new reads to happen in parallel
-  for(uint8_t i = 0; i < numBytes; ++i){
-    rxBuffer[i] = inBytes[i];    
-  }
-  // set rx iterator vars
-  rxBufferIndex = 0;
-  rxBufferLength = numBytes;
-  // alert user program
-  user_onReceive(numBytes);
-}
-
-// behind the scenes function that is called when data is requested
-void TwoWire::onRequestService(void)
-{
-  // don't bother if user hasn't registered a callback
-  if(!user_onRequest){
-    return;
-  }
-  // reset tx buffer iterator vars
-  // !!! this will kill any pending pre-master sendTo() activity
-  txBufferIndex = 0;
-  txBufferLength = 0;
-  // alert user program
-  user_onRequest();
-}
-
-// sets function called on slave write
-void TwoWire::onReceive( void (*function)(int) )
-{
-  user_onReceive = function;
-}
-
-// sets function called on slave read
-void TwoWire::onRequest( void (*function)(void) )
-{
-  user_onRequest = function;
-}
-
-// Preinstantiate Objects //////////////////////////////////////////////////////
-
-TwoWire Wire = TwoWire();
-
-#endif // __AVR__
+#endif

--- a/Wire.cpp
+++ b/Wire.cpp
@@ -347,7 +347,7 @@ uint8_t TwoWire::isr(WIRE_STRUCT *pwires, KINETIS_I2C_t * kinetisk_pi2c)
 //  I2C1_C2      // I2C Control Register 2
 //  I2C1_FLT     // I2C Programmable Input Glitch Filter register
 
-uint8_t TwoWire::i2c_status(KINETIS_I2C_t  *kinetisk_pi2c)
+inline uint8_t TwoWire::i2c_status(KINETIS_I2C_t  *kinetisk_pi2c)
 {
 #if 0	
 	static uint32_t p=0xFFFF;

--- a/Wire.h
+++ b/Wire.h
@@ -80,7 +80,7 @@ class TwoWire: public Stream
     static uint8_t isr(WIRE_STRUCT *pwires,  KINETIS_I2C_t * kinetisk_pi2c);			// Process each of the ISRs...
 
     inline uint8_t i2c_status(KINETIS_I2C_t  *kinetisk_pi2c);
-	inline void i2c_wait(KINETIS_I2C_t  *kinetisk_pi2c);
+	void i2c_wait(KINETIS_I2C_t  *kinetisk_pi2c);
     void checkAndAllocateStruct(void);
   public:
     TwoWire();

--- a/Wire.h
+++ b/Wire.h
@@ -25,13 +25,133 @@
 #include <inttypes.h>
 #include "Arduino.h"
 
+// You can choose which of these optional Wire objects to be created.  Note: they will only be created
+// for those boards who support a particular Wire buss...
+#define WIRE_DEFINE_WIRE0 
+#define WIRE_DEFINE_WIRE1
+#define WIRE_DEFINE_WIRE2
+#define WIRE_DEFINE_WIRE3
+
 #define BUFFER_LENGTH 32
 #define WIRE_HAS_END 1
 
+// If it is not ARM and CORE_TEENSY we will do default stuff...
 #if defined(__arm__) && defined(CORE_TEENSY)
-extern "C" void i2c0_isr(void);
+// Lets create a base class to see if we can share  code 
+#ifndef WIRE_RX_BUFFER_LENGTH
+#define WIRE_RX_BUFFER_LENGTH BUFFER_LENGTH
 #endif
 
+#ifndef WIRE_TX_BUFFER_LENGTH
+#define WIRE_TX_BUFFER_LENGTH (BUFFER_LENGTH+1)
+#endif
+
+typedef struct wire_struct_{
+    // Move all of the main data out of class and only allocate if the user calls begin...
+    uint8_t rxBuffer[WIRE_RX_BUFFER_LENGTH];
+    volatile uint8_t rxBufferIndex;
+    volatile uint8_t rxBufferLength;
+
+    uint8_t txAddress;
+    uint8_t txBuffer[WIRE_TX_BUFFER_LENGTH];
+    volatile uint8_t txBufferIndex;
+    volatile uint8_t txBufferLength;
+    uint8_t slave_mode;
+
+    volatile uint8_t transmitting;
+    volatile uint8_t receiving;          // Our we receiving...
+    volatile uint8_t irqcount;
+
+    void (*user_onRequest)(void);
+    void (*user_onReceive)(int);
+
+} WIRE_STRUCT;
+
+class TwoWire: public Stream
+{
+  protected:
+    struct wire_struct_ *_pwires;
+
+    void onRequestService(void);
+    void onReceiveService(uint8_t*, int);
+    static void sda_rising_isr(void);
+    uint8_t sda_pin_num;
+    uint8_t scl_pin_num;
+    static uint8_t isr(WIRE_STRUCT *pwires,  KINETIS_I2C_t * kinetisk_pi2c);			// Process each of the ISRs...
+
+    inline uint8_t i2c_status(KINETIS_I2C_t  *kinetisk_pi2c);
+	inline void i2c_wait(KINETIS_I2C_t  *kinetisk_pi2c);
+    void checkAndAllocateStruct(void);
+  public:
+    TwoWire();
+    virtual void begin() = 0;               // Alllocate structure
+    virtual void begin(uint8_t) = 0;
+    void begin(int);
+    virtual void end();                     // Frees up data structures
+    void setClock(uint32_t);
+    virtual void setSDA(uint8_t) = 0;
+    virtual void setSCL(uint8_t) = 0;
+    virtual uint8_t checkSIM_SCG() = 0;
+    void beginTransmission(uint8_t);
+    void beginTransmission(int);
+    uint8_t endTransmission(void);
+    uint8_t endTransmission(uint8_t);
+    uint8_t requestFrom(uint8_t, uint8_t);
+    uint8_t requestFrom(uint8_t, uint8_t, uint8_t);
+    uint8_t requestFrom(int, int);
+    uint8_t requestFrom(int, int, int);
+    void send(uint8_t *s, uint8_t n);
+    void send(int n);
+    void send(char *s);
+    uint8_t receive(void);
+    
+    virtual size_t write(uint8_t);
+    virtual size_t write(const uint8_t *, size_t);
+    virtual int available(void);
+    virtual int read(void);
+    virtual int peek(void);
+	virtual void flush(void);
+    void onReceive( void (*)(int) );
+    void onRequest( void (*)(void) );
+    virtual KINETIS_I2C_t *kinetisk_i2c (void) = 0;
+  
+    inline size_t write(unsigned long n) { return write((uint8_t)n); }
+    inline size_t write(long n) { return write((uint8_t)n); }
+    inline size_t write(unsigned int n) { return write((uint8_t)n); }
+    inline size_t write(int n) { return write((uint8_t)n); }
+    using Print::write;
+};
+
+#if defined(WIRE_DEFINE_WIRE0) 
+extern "C" void i2c0_isr(void);
+
+class TwoWire0 : public TwoWire
+{
+  private:
+    static void sda_rising_isr(void);
+    friend void i2c0_isr(void);
+  public:
+    TwoWire0();
+    virtual void begin();
+    virtual void begin(uint8_t);
+    virtual void end();
+    virtual void setSDA(uint8_t);
+    virtual void setSCL(uint8_t);
+    virtual uint8_t checkSIM_SCG();
+    virtual KINETIS_I2C_t *kinetisk_i2c (void);
+
+
+
+    using TwoWire::write;
+};
+
+extern TwoWire0 Wire;
+#endif
+
+#else
+
+// AVR version 
+#if defined(WIRE_DEFINE_WIRE0) 
 class TwoWire : public Stream
 {
   private:
@@ -50,11 +170,6 @@ class TwoWire : public Stream
     static void (*user_onRequest)(void);
     static void (*user_onReceive)(int);
     static void sda_rising_isr(void);
-#if defined(__arm__) && defined(CORE_TEENSY)
-    static uint8_t sda_pin_num;
-    static uint8_t scl_pin_num;
-    friend void i2c0_isr(void);
-#endif
   public:
     TwoWire();
     void begin();
@@ -102,6 +217,8 @@ class TwoWire : public Stream
 };
 
 extern TwoWire Wire;
+#endif
+#endif
 
 #if defined(__arm__) && defined(CORE_TEENSY)
 class TWBRemulation
@@ -232,6 +349,86 @@ public:
 };
 extern TWBRemulation TWBR;
 #endif
+
+
+// T3.1, 3.2, 3.5, 3.6 and TLC all have WIRE1...
+#if defined(__MK20DX256__) || defined(__MK64FX512__) || defined(__MK66FX1M0__) || defined(__MKL26Z64__)
+
+#if defined(WIRE_DEFINE_WIRE1)
+extern "C" void i2c1_isr(void);
+
+class TwoWire1: public TwoWire
+{
+  private:
+    static void sda_rising_isr(void);
+    friend void i2c1_isr(void);
+  public:
+    TwoWire1();
+    virtual void begin();
+    virtual void begin(uint8_t);
+    virtual void end();
+    virtual void setSDA(uint8_t);
+    virtual void setSCL(uint8_t);
+    virtual uint8_t checkSIM_SCG();
+    virtual KINETIS_I2C_t *kinetisk_i2c (void);
+
+    using TwoWire::write;
+};
+
+extern TwoWire1 Wire1;
+#endif
+#endif
+
+// Teensy 3.5 and T3.6 also have Wire2
+#if defined(WIRE_DEFINE_WIRE2) && (defined(__MK64FX512__) || defined(__MK66FX1M0__))
+extern "C" void i2c2_isr(void);
+
+class TwoWire2: public TwoWire
+{
+  private:
+    static void sda_rising_isr(void);
+    friend void i2c2_isr(void);
+  public:
+    TwoWire2();
+    virtual void begin();
+    virtual void begin(uint8_t);
+    virtual void end();
+    virtual void setSDA(uint8_t);
+    virtual void setSCL(uint8_t);
+    virtual uint8_t checkSIM_SCG();
+    virtual KINETIS_I2C_t *kinetisk_i2c (void);
+
+    using TwoWire::write;
+};
+
+extern TwoWire2 Wire2;
+#endif
+
+// Only T3.6 has Wire3
+#if defined(WIRE_DEFINE_WIRE3) && defined(__MK66FX1M0__)
+extern "C" void i2c3_isr(void);
+
+class TwoWire3: public TwoWire
+{
+  private:
+    static void sda_rising_isr(void);
+    friend void i2c3_isr(void);
+  public:
+    TwoWire3();
+    virtual void begin();
+    virtual void begin(uint8_t);
+    virtual void end();
+    virtual void setSDA(uint8_t);
+    virtual void setSCL(uint8_t);
+    virtual uint8_t checkSIM_SCG();
+    virtual KINETIS_I2C_t *kinetisk_i2c (void);
+
+    using TwoWire::write;
+};
+
+extern TwoWire3 Wire3;
+#endif
+
 
 #endif
 

--- a/Wire0.cpp
+++ b/Wire0.cpp
@@ -1,0 +1,553 @@
+/*
+  TwoWire.cpp - TWI/I2C library for Wiring & Arduino
+  Copyright (c) 2006 Nicholas Zambetti.  All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ 
+  Modified 2012 by Todd Krein (todd@krein.org) to implement repeated starts
+*/
+
+#include "Wire.h"
+#if defined (WIRE_DEFINE_WIRE0)
+#if defined(__arm__) && defined(CORE_TEENSY)
+
+#include "kinetis.h"
+#include <string.h> // for memcpy
+#include "core_pins.h"
+//#include "HardwareSerial.h"
+#include "Wire.h"
+
+TwoWire0::TwoWire0() : TwoWire()
+{
+	sda_pin_num = A4;
+	scl_pin_num = A5;
+}
+
+KINETIS_I2C_t *TwoWire0::kinetisk_i2c (void) {
+    return &KINETIS_I2C0;
+}
+
+
+void TwoWire0::begin(void) 
+{
+	// Make sure we have our data structure allocated. 
+	checkAndAllocateStruct();
+	//serial_begin(BAUD2DIV(115200));
+	//serial_print("\nWire Begin\n");
+
+	_pwires->slave_mode = 0;
+	SIM_SCGC4 |= SIM_SCGC4_I2C0; // TODO: use bitband
+	I2C0_C1 = 0;
+	// On Teensy 3.0 external pullup resistors *MUST* be used
+	// the PORT_PCR_PE bit is ignored when in I2C mode
+	// I2C will not work at all without pullup resistors
+	// It might seem like setting PORT_PCR_PE & PORT_PCR_PS
+	// would enable pullup resistors.  However, there seems
+	// to be a bug in chip while I2C is enabled, where setting
+	// those causes the port to be driven strongly high.
+	if (sda_pin_num == 18) {
+		CORE_PIN18_CONFIG = PORT_PCR_MUX(2)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
+	} else if (sda_pin_num == 17) {
+		CORE_PIN17_CONFIG = PORT_PCR_MUX(2)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
+#if defined(__MK64FX512__) || defined(__MK66FX1M0__)
+	} else if (sda_pin_num == 34) {
+		CORE_PIN34_CONFIG = PORT_PCR_MUX(5)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
+	} else if (sda_pin_num == 8) {
+		CORE_PIN8_CONFIG = PORT_PCR_MUX(7)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
+	} else if (sda_pin_num == 48) {
+		CORE_PIN48_CONFIG = PORT_PCR_MUX(2)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
+#endif	
+	}
+	if (scl_pin_num == 19) {
+		CORE_PIN19_CONFIG = PORT_PCR_MUX(2)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
+	} else if (scl_pin_num == 16) {
+		CORE_PIN16_CONFIG = PORT_PCR_MUX(2)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
+#if defined(__MK64FX512__) || defined(__MK66FX1M0__)
+	} else if (scl_pin_num == 33) {
+		CORE_PIN33_CONFIG = PORT_PCR_MUX(5)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
+	} else if (scl_pin_num == 7) {
+		CORE_PIN7_CONFIG = PORT_PCR_MUX(7)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
+	} else if (scl_pin_num == 47) {
+		CORE_PIN47_CONFIG = PORT_PCR_MUX(2)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
+#endif	
+	}
+	setClock(100000);
+	I2C0_C2 = I2C_C2_HDRS;
+	I2C0_C1 = I2C_C1_IICEN;
+	//pinMode(3, OUTPUT);
+	//pinMode(4, OUTPUT);
+}
+
+
+void TwoWire0::setSDA(uint8_t pin)
+{
+	if (pin == sda_pin_num) return;
+	if ((SIM_SCGC4 & SIM_SCGC4_I2C0)) {
+		if (sda_pin_num == 18) {
+			CORE_PIN18_CONFIG = 0;
+		} else if (sda_pin_num == 17) {
+			CORE_PIN17_CONFIG = 0;
+#if defined(__MK64FX512__) || defined(__MK66FX1M0__)
+		} else if (sda_pin_num == 34) {
+			CORE_PIN34_CONFIG = 0;
+		} else if (sda_pin_num == 8) {
+			CORE_PIN8_CONFIG = 0;
+		} else if (sda_pin_num == 48) {
+			CORE_PIN48_CONFIG = 0;
+#endif	
+		}
+
+		if (pin == 18) {
+			CORE_PIN18_CONFIG = PORT_PCR_MUX(2)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
+		} else if (pin == 17) {
+			CORE_PIN17_CONFIG = PORT_PCR_MUX(2)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
+#if defined(__MK64FX512__) || defined(__MK66FX1M0__)
+		} else if (pin == 34) {
+			CORE_PIN34_CONFIG = PORT_PCR_MUX(5)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
+		} else if (pin == 8) {
+			CORE_PIN8_CONFIG = PORT_PCR_MUX(7)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
+		} else if (pin == 48) {
+			CORE_PIN48_CONFIG = PORT_PCR_MUX(2)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
+#endif	
+		}
+	}
+	sda_pin_num = pin;
+}
+
+void TwoWire0::setSCL(uint8_t pin)
+{
+	if (pin == scl_pin_num) return;
+	if ((SIM_SCGC4 & SIM_SCGC4_I2C0)) {
+		if (scl_pin_num == 19) {
+			CORE_PIN19_CONFIG = 0;
+		} else if (scl_pin_num == 16) {
+			CORE_PIN16_CONFIG = 0;
+#if defined(__MK64FX512__) || defined(__MK66FX1M0__)
+		} else if (scl_pin_num == 33) {
+			CORE_PIN33_CONFIG = 0;
+		} else if (scl_pin_num == 7) {
+			CORE_PIN7_CONFIG = 0;
+		} else if (scl_pin_num == 47) {
+			CORE_PIN47_CONFIG = 0;
+#endif	
+		}
+
+		if (pin == 19) {
+			CORE_PIN19_CONFIG = PORT_PCR_MUX(2)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
+		} else if (pin == 16) {
+			CORE_PIN16_CONFIG = PORT_PCR_MUX(2)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
+#if defined(__MK64FX512__) || defined(__MK66FX1M0__)
+		} else if (pin == 33) {
+			CORE_PIN33_CONFIG = PORT_PCR_MUX(5)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
+		} else if (pin == 7) {
+			CORE_PIN7_CONFIG = PORT_PCR_MUX(7)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
+		} else if (pin == 47) {
+			CORE_PIN47_CONFIG = PORT_PCR_MUX(2)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
+#endif	
+		}
+	}
+	scl_pin_num = pin;
+}
+
+void TwoWire0::begin(uint8_t address)
+{
+	begin();
+	I2C0_A1 = address << 1;
+	_pwires->slave_mode = 1;
+	I2C0_C1 = I2C_C1_IICEN | I2C_C1_IICIE;
+	NVIC_ENABLE_IRQ(IRQ_I2C0);
+}
+
+uint8_t TwoWire0::checkSIM_SCG()
+{
+	return ( SIM_SCGC4 & SIM_SCGC4_I2C0)? 1 : 0;  //Test to see if we have done a begin...
+
+}
+
+void TwoWire0::end()
+{
+	if (!(SIM_SCGC4 & SIM_SCGC4_I2C0)) return;
+	NVIC_DISABLE_IRQ(IRQ_I2C0);
+	I2C0_C1 = 0;
+	if (sda_pin_num == 18) {
+		CORE_PIN18_CONFIG = 0;
+	} else if (sda_pin_num == 17) {
+		CORE_PIN17_CONFIG = 0;
+#if defined(__MK64FX512__) || defined(__MK66FX1M0__)
+	} else if (sda_pin_num == 34) {
+		CORE_PIN34_CONFIG = 0;
+	} else if (sda_pin_num == 8) {
+		CORE_PIN8_CONFIG = 0;
+	} else if (sda_pin_num == 48) {
+		CORE_PIN48_CONFIG = 0;
+#endif	
+	}
+	if (scl_pin_num == 19) {
+		CORE_PIN19_CONFIG = 0;
+	} else if (scl_pin_num == 16) {
+		CORE_PIN16_CONFIG = 0;
+#if defined(__MK64FX512__) || defined(__MK66FX1M0__)
+	} else if (scl_pin_num == 33) {
+		CORE_PIN33_CONFIG = 0;
+	} else if (scl_pin_num == 7) {
+		CORE_PIN7_CONFIG = 0;
+	} else if (scl_pin_num == 47) {
+		CORE_PIN47_CONFIG = 0;
+#endif	
+	}
+	SIM_SCGC4 &= ~SIM_SCGC4_I2C0; // TODO: use bitband
+	TwoWire::end();
+}
+
+void i2c0_isr(void)
+{
+	if (Wire.isr(Wire._pwires, &KINETIS_I2C0 )) {
+		// Hack that mainline function says to set
+		attachInterrupt(Wire.sda_pin_num, TwoWire0::sda_rising_isr, RISING);
+	}
+
+}
+
+// Detects the stop condition that terminates a slave receive transfer.
+// Sadly, the I2C in Kinetis K series lacks the stop detect interrupt
+// This pin change interrupt hack is needed to detect the stop condition
+void TwoWire0::sda_rising_isr(void)
+{
+	WIRE_STRUCT *pwires = Wire._pwires;
+	if (!(I2C0_S & I2C_S_BUSY)) {
+		detachInterrupt(Wire.sda_pin_num);
+		if (pwires->user_onReceive != NULL) {
+			pwires->rxBufferIndex = 0;
+			pwires->user_onReceive(pwires->rxBufferLength);
+		}
+		//delayMicroseconds(100);
+	} else {
+		if (++pwires->irqcount >= 2 || !pwires->slave_mode) {
+			detachInterrupt(Wire.sda_pin_num);
+		}
+	}
+}
+
+
+
+//TwoWire Wire = TwoWire();
+TwoWire0 Wire;
+
+
+#endif // __MK20DX128__ || __MK20DX256__
+
+
+
+#if defined(__AVR__)
+
+extern "C" {
+  #include <stdlib.h>
+  #include <string.h>
+  #include <inttypes.h>
+  #include "twi.h"
+}
+
+
+// Initialize Class Variables //////////////////////////////////////////////////
+
+uint8_t TwoWire::rxBuffer[BUFFER_LENGTH];
+uint8_t TwoWire::rxBufferIndex = 0;
+uint8_t TwoWire::rxBufferLength = 0;
+
+uint8_t TwoWire::txAddress = 0;
+uint8_t TwoWire::txBuffer[BUFFER_LENGTH];
+uint8_t TwoWire::txBufferIndex = 0;
+uint8_t TwoWire::txBufferLength = 0;
+
+uint8_t TwoWire::transmitting = 0;
+void (*TwoWire::user_onRequest)(void);
+void (*TwoWire::user_onReceive)(int);
+
+// Constructors ////////////////////////////////////////////////////////////////
+
+TwoWire::TwoWire()
+{
+}
+
+// Public Methods //////////////////////////////////////////////////////////////
+
+void TwoWire::begin(void)
+{
+  rxBufferIndex = 0;
+  rxBufferLength = 0;
+
+  txBufferIndex = 0;
+  txBufferLength = 0;
+
+  twi_init();
+}
+
+void TwoWire::begin(uint8_t address)
+{
+  twi_setAddress(address);
+  twi_attachSlaveTxEvent(onRequestService);
+  twi_attachSlaveRxEvent(onReceiveService);
+  begin();
+}
+
+void TwoWire::begin(int address)
+{
+  begin((uint8_t)address);
+}
+
+void TwoWire::end()
+{
+  TWCR &= ~(_BV(TWEN) | _BV(TWIE) | _BV(TWEA));
+  digitalWrite(SDA, 0);
+  digitalWrite(SCL, 0);
+}
+
+void TwoWire::setClock(uint32_t frequency)
+{
+  TWBR = ((F_CPU / frequency) - 16) / 2;
+}
+
+void TwoWire::setSDA(uint8_t pin)
+{
+}
+
+void TwoWire::setSCL(uint8_t pin)
+{
+}
+
+uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint8_t sendStop)
+{
+  // clamp to buffer length
+  if(quantity > BUFFER_LENGTH){
+    quantity = BUFFER_LENGTH;
+  }
+  // perform blocking read into buffer
+  uint8_t read = twi_readFrom(address, rxBuffer, quantity, sendStop);
+  // set rx buffer iterator vars
+  rxBufferIndex = 0;
+  rxBufferLength = read;
+
+  return read;
+}
+
+uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity)
+{
+  return requestFrom((uint8_t)address, (uint8_t)quantity, (uint8_t)true);
+}
+
+uint8_t TwoWire::requestFrom(int address, int quantity)
+{
+  return requestFrom((uint8_t)address, (uint8_t)quantity, (uint8_t)true);
+}
+
+uint8_t TwoWire::requestFrom(int address, int quantity, int sendStop)
+{
+  return requestFrom((uint8_t)address, (uint8_t)quantity, (uint8_t)sendStop);
+}
+
+void TwoWire::beginTransmission(uint8_t address)
+{
+  // indicate that we are transmitting
+  transmitting = 1;
+  // set address of targeted slave
+  txAddress = address;
+  // reset tx buffer iterator vars
+  txBufferIndex = 0;
+  txBufferLength = 0;
+}
+
+void TwoWire::beginTransmission(int address)
+{
+  beginTransmission((uint8_t)address);
+}
+
+//
+//	Originally, 'endTransmission' was an f(void) function.
+//	It has been modified to take one parameter indicating
+//	whether or not a STOP should be performed on the bus.
+//	Calling endTransmission(false) allows a sketch to 
+//	perform a repeated start. 
+//
+//	WARNING: Nothing in the library keeps track of whether
+//	the bus tenure has been properly ended with a STOP. It
+//	is very possible to leave the bus in a hung state if
+//	no call to endTransmission(true) is made. Some I2C
+//	devices will behave oddly if they do not see a STOP.
+//
+uint8_t TwoWire::endTransmission(uint8_t sendStop)
+{
+  // transmit buffer (blocking)
+  int8_t ret = twi_writeTo(txAddress, txBuffer, txBufferLength, 1, sendStop);
+  // reset tx buffer iterator vars
+  txBufferIndex = 0;
+  txBufferLength = 0;
+  // indicate that we are done transmitting
+  transmitting = 0;
+  return ret;
+}
+
+//	This provides backwards compatibility with the original
+//	definition, and expected behaviour, of endTransmission
+//
+uint8_t TwoWire::endTransmission(void)
+{
+  return endTransmission(true);
+}
+
+// must be called in:
+// slave tx event callback
+// or after beginTransmission(address)
+size_t TwoWire::write(uint8_t data)
+{
+  if(transmitting){
+  // in master transmitter mode
+    // don't bother if buffer is full
+    if(txBufferLength >= BUFFER_LENGTH){
+      setWriteError();
+      return 0;
+    }
+    // put byte in tx buffer
+    txBuffer[txBufferIndex] = data;
+    ++txBufferIndex;
+    // update amount in buffer   
+    txBufferLength = txBufferIndex;
+  }else{
+  // in slave send mode
+    // reply to master
+    twi_transmit(&data, 1);
+  }
+  return 1;
+}
+
+// must be called in:
+// slave tx event callback
+// or after beginTransmission(address)
+size_t TwoWire::write(const uint8_t *data, size_t quantity)
+{
+  if(transmitting){
+  // in master transmitter mode
+    for(size_t i = 0; i < quantity; ++i){
+      write(data[i]);
+    }
+  }else{
+  // in slave send mode
+    // reply to master
+    twi_transmit(data, quantity);
+  }
+  return quantity;
+}
+
+// must be called in:
+// slave rx event callback
+// or after requestFrom(address, numBytes)
+int TwoWire::available(void)
+{
+  return rxBufferLength - rxBufferIndex;
+}
+
+// must be called in:
+// slave rx event callback
+// or after requestFrom(address, numBytes)
+int TwoWire::read(void)
+{
+  int value = -1;
+  
+  // get each successive byte on each call
+  if(rxBufferIndex < rxBufferLength){
+    value = rxBuffer[rxBufferIndex];
+    ++rxBufferIndex;
+  }
+
+  return value;
+}
+
+// must be called in:
+// slave rx event callback
+// or after requestFrom(address, numBytes)
+int TwoWire::peek(void)
+{
+  int value = -1;
+  
+  if(rxBufferIndex < rxBufferLength){
+    value = rxBuffer[rxBufferIndex];
+  }
+
+  return value;
+}
+
+void TwoWire::flush(void)
+{
+  // XXX: to be implemented.
+}
+
+// behind the scenes function that is called when data is received
+void TwoWire::onReceiveService(uint8_t* inBytes, int numBytes)
+{
+  // don't bother if user hasn't registered a callback
+  if(!user_onReceive){
+    return;
+  }
+  // don't bother if rx buffer is in use by a master requestFrom() op
+  // i know this drops data, but it allows for slight stupidity
+  // meaning, they may not have read all the master requestFrom() data yet
+  if(rxBufferIndex < rxBufferLength){
+    return;
+  }
+  // copy twi rx buffer into local read buffer
+  // this enables new reads to happen in parallel
+  for(uint8_t i = 0; i < numBytes; ++i){
+    rxBuffer[i] = inBytes[i];    
+  }
+  // set rx iterator vars
+  rxBufferIndex = 0;
+  rxBufferLength = numBytes;
+  // alert user program
+  user_onReceive(numBytes);
+}
+
+// behind the scenes function that is called when data is requested
+void TwoWire::onRequestService(void)
+{
+  // don't bother if user hasn't registered a callback
+  if(!user_onRequest){
+    return;
+  }
+  // reset tx buffer iterator vars
+  // !!! this will kill any pending pre-master sendTo() activity
+  txBufferIndex = 0;
+  txBufferLength = 0;
+  // alert user program
+  user_onRequest();
+}
+
+// sets function called on slave write
+void TwoWire::onReceive( void (*function)(int) )
+{
+  user_onReceive = function;
+}
+
+// sets function called on slave read
+void TwoWire::onRequest( void (*function)(void) )
+{
+  user_onRequest = function;
+}
+
+// Preinstantiate Objects //////////////////////////////////////////////////////
+
+TwoWire Wire = TwoWire();
+
+#endif // __AVR__
+
+#endif // WIRE_DEFINE_WIRE0

--- a/Wire1.cpp
+++ b/Wire1.cpp
@@ -1,0 +1,242 @@
+/*
+  TwoWire.cpp - TWI/I2C library for Wiring & Arduino
+  Copyright (c) 2006 Nicholas Zambetti.  All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ 
+  Modified 2012 by Todd Krein (todd@krein.org) to implement repeated starts
+*/
+
+#include "Wire.h"
+
+#if defined(WIRE_DEFINE_WIRE1) && (defined(__MK20DX256__) || defined(__MK64FX512__) || defined(__MK66FX1M0__) || defined(__MKL26Z64__))
+
+#include "kinetis.h"
+#include <string.h> // for memcpy
+#include "core_pins.h"
+//#include "HardwareSerial.h"
+#include "Wire.h"
+
+
+TwoWire1::TwoWire1() : TwoWire()
+{
+
+#if defined(__MK20DX256__) // T3.2
+	sda_pin_num = 30;
+	scl_pin_num = 29;
+#elif defined(__MK64FX512__) || defined(__MK66FX1M0__)  // T3.5/3.6
+	sda_pin_num = 38;
+	scl_pin_num = 37;
+#elif defined(__MKL26Z64__)
+	sda_pin_num = 23;
+	scl_pin_num = 22;
+#endif
+}
+
+KINETIS_I2C_t *TwoWire1::kinetisk_i2c (void) {
+    return &KINETIS_I2C1;
+}
+
+
+void TwoWire1::begin(void)
+{
+	//serial_begin(BAUD2DIV(115200));
+	//serial_print("\nWire Begin\n");
+	//Serial.printf("TwoWire1::Begin SCL: %d SDA: %d\n", scl_pin_num, sda_pin_num);
+
+	// Make sure we have our data structure allocated. 
+	checkAndAllocateStruct();
+
+	_pwires->slave_mode = 0;
+	SIM_SCGC4 |= SIM_SCGC4_I2C1; // TODO: use bitband
+
+	KINETIS_I2C1.C1 = 0;
+	// On Teensy 3.0 external pullup resistors *MUST* be used
+	// the PORT_PCR_PE bit is ignored when in I2C mode
+	// I2C will not work at all without pullup resistors
+	// It might seem like setting PORT_PCR_PE & PORT_PCR_PS
+	// would enable pullup resistors.  However, there seems
+	// to be a bug in chip while I2C is enabled, where setting
+	// those causes the port to be driven strongly high.
+    //      Wire1: I2C_PINS_29_30 (3.1/3.2), I2C_PINS_22_23 (LC), I2C_PINS_37_38 (3.5/3.6)
+#if defined(__MK20DX256__) // T3.2
+	if (scl_pin_num == 29) {
+		CORE_PIN29_CONFIG = PORT_PCR_MUX(2)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
+	}
+	if (sda_pin_num == 30) {
+		CORE_PIN30_CONFIG = PORT_PCR_MUX(2)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
+	}
+#elif defined(__MK64FX512__) || defined(__MK66FX1M0__)  // T3.5/3.6
+	if (scl_pin_num == 37) {
+		CORE_PIN37_CONFIG = PORT_PCR_MUX(2)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
+	} else 	if (scl_pin_num == 59) {
+		CORE_PIN59_CONFIG = PORT_PCR_MUX(2)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
+	}
+	if (sda_pin_num == 38) {
+		CORE_PIN38_CONFIG = PORT_PCR_MUX(2)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
+	} else 	if (sda_pin_num == 58) {
+		CORE_PIN58_CONFIG = PORT_PCR_MUX(2)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
+	}
+#elif defined(__MKL26Z64__)
+	if (scl_pin_num == 22) {
+		CORE_PIN22_CONFIG = PORT_PCR_MUX(2)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
+	}
+	if (sda_pin_num == 23) {
+		CORE_PIN23_CONFIG = PORT_PCR_MUX(2)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
+	}
+#endif
+	setClock(100000);
+	KINETIS_I2C1.C2 = I2C_C2_HDRS;
+	KINETIS_I2C1.C1 = I2C_C1_IICEN;
+	//pinMode(3, OUTPUT);
+	//pinMode(4, OUTPUT);
+}
+
+
+void TwoWire1::begin(uint8_t address)
+{
+	begin();
+	KINETIS_I2C1.A1 = address << 1;
+	_pwires->slave_mode = 1;
+	KINETIS_I2C1.C1 = I2C_C1_IICEN | I2C_C1_IICIE;
+	NVIC_ENABLE_IRQ(IRQ_I2C1);
+}
+
+
+void TwoWire1::setSDA(uint8_t pin)
+{
+	if (pin == sda_pin_num) return;
+
+	if ((SIM_SCGC4 & SIM_SCGC4_I2C1)) {
+		// currently only T3.5/T3.6 have multiple pins...
+#if defined(__MK64FX512__) || defined(__MK66FX1M0__)  // T3.5/3.6
+		if (sda_pin_num == 38) {
+			CORE_PIN38_CONFIG = 0;
+		} else 	if (sda_pin_num == 58) {
+			CORE_PIN58_CONFIG = 0;
+		}
+
+		if (pin == 38) {
+			CORE_PIN38_CONFIG = PORT_PCR_MUX(2)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
+		} else 	if (pin == 58) {
+			CORE_PIN58_CONFIG = PORT_PCR_MUX(2)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
+		}
+#endif
+	}
+	sda_pin_num = pin;
+}
+
+void TwoWire1::setSCL(uint8_t pin)
+{
+	if (pin == scl_pin_num) return;
+	if ((SIM_SCGC4 & SIM_SCGC4_I2C1)) {
+#if defined(__MK64FX512__) || defined(__MK66FX1M0__)  // T3.5/3.6
+		if (scl_pin_num == 37) {
+			CORE_PIN37_CONFIG = 0;
+		} else 	if (scl_pin_num == 59) {
+			CORE_PIN59_CONFIG = 0;
+		}
+		if (pin == 37) {
+			CORE_PIN37_CONFIG = PORT_PCR_MUX(2)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
+		} else 	if (pin == 59) {
+			CORE_PIN59_CONFIG = PORT_PCR_MUX(2)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
+		}
+#endif
+	}
+	scl_pin_num = pin;
+}
+
+uint8_t TwoWire1::checkSIM_SCG()
+{
+	return ( SIM_SCGC4 & SIM_SCGC4_I2C1)? 1 : 0;  //Test to see if we have done a begin...
+
+}
+
+
+void TwoWire1::end()
+{
+	if (!(SIM_SCGC4 & SIM_SCGC4_I2C1)) return;
+	NVIC_DISABLE_IRQ(IRQ_I2C1);
+	KINETIS_I2C1.C1 = 0;
+#if defined(__MK20DX256__) // T3.2
+	if (scl_pin_num == 29) {
+		CORE_PIN29_CONFIG = 0;
+	}
+	if (sda_pin_num == 30) {
+		CORE_PIN30_CONFIG = 0;
+	}
+#elif defined(__MK64FX512__) || defined(__MK66FX1M0__)  // T3.5/3.6
+	if (scl_pin_num == 37) {
+		CORE_PIN37_CONFIG = 0;
+	} else 	if (scl_pin_num == 59) {
+		CORE_PIN59_CONFIG = 0;
+	}
+	if (sda_pin_num == 38) {
+		CORE_PIN38_CONFIG = 0;
+	} else 	if (sda_pin_num == 58) {
+		CORE_PIN58_CONFIG = 0;
+	}
+#elif defined(__MKL26Z64__)
+	if (scl_pin_num == 22) {
+		CORE_PIN22_CONFIG = 0;
+	}
+	if (sda_pin_num == 23) {
+		CORE_PIN23_CONFIG = 0;
+	}
+#endif
+	SIM_SCGC4 &= ~SIM_SCGC4_I2C1; // TODO: use bitband
+	TwoWire::end();
+
+}
+
+void i2c1_isr(void)
+{
+	if (Wire1.isr(Wire1._pwires, &KINETIS_I2C1) ) {
+
+		// Hack that mainline function says to set
+		attachInterrupt(Wire1.sda_pin_num, TwoWire1::sda_rising_isr, RISING);
+	}
+
+}
+
+// Detects the stop condition that terminates a slave receive transfer.
+// Sadly, the I2C in Kinetis K series lacks the stop detect interrupt
+// This pin change interrupt hack is needed to detect the stop condition
+void TwoWire1::sda_rising_isr(void)
+{
+	//digitalWrite(3, HIGH);
+	WIRE_STRUCT *pwires = Wire1._pwires;
+	if (!(I2C1_S & I2C_S_BUSY)) {
+		detachInterrupt(Wire1.sda_pin_num);
+		if (pwires->user_onReceive != NULL) {
+			pwires->rxBufferIndex = 0;
+			pwires->user_onReceive(pwires->rxBufferLength);
+		}
+		//delayMicroseconds(100);
+	} else {
+		if (++pwires->irqcount >= 2 || !pwires->slave_mode) {
+			detachInterrupt(Wire1.sda_pin_num);
+		}
+	}
+	//digitalWrite(3, LOW);
+}
+
+
+//TwoWire Wire = TwoWire();
+TwoWire1 Wire1;
+
+
+#endif // __MK20DX256__ || __MK64FX512__ || __MK66FX1M0__ || __MKL26Z64__
+

--- a/Wire2.cpp
+++ b/Wire2.cpp
@@ -1,0 +1,167 @@
+/*
+  TwoWire.cpp - TWI/I2C library for Wiring & Arduino
+  Copyright (c) 2006 Nicholas Zambetti.  All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ 
+  Modified 2012 by Todd Krein (todd@krein.org) to implement repeated starts
+*/
+
+#include "Wire.h"
+
+// Only T3.5 and T3.6
+#if defined(WIRE_DEFINE_WIRE2) && (defined(__MK64FX512__) || defined(__MK66FX1M0__))
+
+#include "kinetis.h"
+#include <string.h> // for memcpy
+#include "core_pins.h"
+//#include "HardwareSerial.h"
+#include "Wire.h"
+
+
+TwoWire2::TwoWire2() : TwoWire()
+{
+	sda_pin_num = 4;  // only 1 valid one
+	scl_pin_num = 3;
+}
+
+KINETIS_I2C_t *TwoWire2::kinetisk_i2c (void) {
+    return &KINETIS_I2C2;
+}
+
+void TwoWire2::begin(void)
+{
+	// Make sure we have our data structure allocated. 
+	checkAndAllocateStruct();
+
+	//serial_begin(BAUD2DIV(115200));
+	//serial_print("\nWire Begin\n");
+	Serial.printf("TwoWire2::Begin SCL: %d SDA: %d\n", scl_pin_num, sda_pin_num);
+	_pwires->slave_mode = 0;
+	SIM_SCGC1 |= SIM_SCGC1_I2C2; // TODO: use bitband
+	KINETIS_I2C2.C1 = 0;
+
+	if (scl_pin_num == 3) {
+		CORE_PIN3_CONFIG = PORT_PCR_MUX(5)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
+	} else 	if (scl_pin_num == 26) {
+		CORE_PIN26_CONFIG = PORT_PCR_MUX(5)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
+	}
+
+	// Only one valid SDA PIN
+	CORE_PIN4_CONFIG = PORT_PCR_MUX(5)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
+
+	setClock(100000);
+	KINETIS_I2C2.C2 = I2C_C2_HDRS;
+	KINETIS_I2C2.C1 = I2C_C1_IICEN;
+}
+
+
+void TwoWire2::begin(uint8_t address)
+{
+	begin();
+	KINETIS_I2C2.A1 = address << 1;
+	_pwires->slave_mode = 1;
+	KINETIS_I2C2.C1 = I2C_C1_IICEN | I2C_C1_IICIE;
+	NVIC_ENABLE_IRQ(IRQ_I2C2);
+}
+
+void TwoWire2::setSDA(uint8_t pin)
+{
+}
+
+void TwoWire2::setSCL(uint8_t pin)
+{
+	if (pin == scl_pin_num) return;
+	if ((SIM_SCGC1 & SIM_SCGC1_I2C2)) {
+		if (scl_pin_num == 3) {
+			CORE_PIN3_CONFIG = 0;
+		} else 	if (scl_pin_num == 26) {
+			CORE_PIN26_CONFIG = 0;
+		}
+
+		if (pin == 3) {
+			CORE_PIN3_CONFIG = PORT_PCR_MUX(5)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
+		} else 	if (pin == 26) {
+			CORE_PIN26_CONFIG = PORT_PCR_MUX(5)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
+		}
+	}
+	scl_pin_num = pin;
+}
+
+uint8_t TwoWire2::checkSIM_SCG()
+{
+	return ( SIM_SCGC1 & SIM_SCGC1_I2C2)? 1 : 0;  //Test to see if we have done a begin...
+
+}
+
+
+void TwoWire2::end()
+{
+	if (!(SIM_SCGC1 & SIM_SCGC1_I2C2)) return;
+	NVIC_DISABLE_IRQ(IRQ_I2C2);
+	KINETIS_I2C2.C1 = 0;
+
+	CORE_PIN4_CONFIG = 0;	// only valid pin
+	if (scl_pin_num == 3) {
+		CORE_PIN3_CONFIG = 0;
+	} else 	if (scl_pin_num == 26) {
+		CORE_PIN26_CONFIG = 0;
+	}
+
+	SIM_SCGC1 &= ~SIM_SCGC1_I2C2; // TODO: use bitband
+	TwoWire::end();
+
+}
+
+void i2c2_isr(void)
+{
+	if (Wire2.isr(Wire2._pwires, &KINETIS_I2C2) ) {
+		// Hack that mainline function says to set
+		attachInterrupt(Wire2.sda_pin_num, TwoWire2::sda_rising_isr, RISING);
+	}
+
+}
+
+// Detects the stop condition that terminates a slave receive transfer.
+// Sadly, the I2C in Kinetis K series lacks the stop detect interrupt
+// This pin change interrupt hack is needed to detect the stop condition
+void TwoWire2::sda_rising_isr(void)
+{
+	//digitalWrite(3, HIGH);
+	WIRE_STRUCT *pwires = Wire2._pwires;
+
+	if (!(I2C2_S & I2C_S_BUSY)) {
+		detachInterrupt(Wire2.sda_pin_num);
+		if (pwires->user_onReceive != NULL) {
+			pwires->rxBufferIndex = 0;
+			pwires->user_onReceive(pwires->rxBufferLength);
+		}
+		//delayMicroseconds(100);
+	} else {
+		if (++pwires->irqcount >= 2 || !pwires->slave_mode) {
+			detachInterrupt(Wire2.sda_pin_num);
+		}
+	}
+	//digitalWrite(3, LOW);
+}
+
+
+
+//TwoWire Wire = TwoWire();
+TwoWire2 Wire2;
+
+
+#endif // __MK64FX512__ || __MK66FX1M0__ 
+

--- a/Wire3.cpp
+++ b/Wire3.cpp
@@ -1,0 +1,140 @@
+/*
+  TwoWire.cpp - TWI/I2C library for Wiring & Arduino
+  Copyright (c) 2006 Nicholas Zambetti.  All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ 
+  Modified 2012 by Todd Krein (todd@krein.org) to implement repeated starts
+*/
+
+#include "Wire.h"
+
+// Only T3.6
+#if defined(WIRE_DEFINE_WIRE1) && defined(__MK66FX1M0__)
+
+#include "kinetis.h"
+#include <string.h> // for memcpy
+#include "core_pins.h"
+//#include "HardwareSerial.h"
+#include "Wire.h"
+
+TwoWire3::TwoWire3() : TwoWire()
+{
+	sda_pin_num = 56;
+	scl_pin_num = 57;
+}
+
+KINETIS_I2C_t *TwoWire3::kinetisk_i2c (void) {
+    return &KINETIS_I2C3;
+}
+
+void TwoWire3::begin(void)
+{
+	// Make sure we have our data structure allocated. 
+	checkAndAllocateStruct();
+
+	//serial_begin(BAUD2DIV(115200));
+	//serial_print("\nWire Begin\n");
+
+	_pwires->slave_mode = 0;
+	SIM_SCGC1 |= SIM_SCGC1_I2C3; // TODO: use bitband
+	KINETIS_I2C3.C1 = 0;
+
+	// Currently only pin each
+	// SCL
+	CORE_PIN56_CONFIG = PORT_PCR_MUX(2)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE; 
+	// SDA
+	CORE_PIN57_CONFIG = PORT_PCR_MUX(2)|PORT_PCR_ODE|PORT_PCR_SRE|PORT_PCR_DSE;
+	setClock(100000);
+	KINETIS_I2C3.C2 = I2C_C2_HDRS;
+	KINETIS_I2C3.C1 = I2C_C1_IICEN;
+}
+
+void TwoWire3::begin(uint8_t address)
+{
+	begin();
+	KINETIS_I2C3.A1 = address << 1;
+	_pwires->slave_mode = 1;
+	KINETIS_I2C3.C1 = I2C_C1_IICEN | I2C_C1_IICIE;
+	NVIC_ENABLE_IRQ(IRQ_I2C3);
+}
+
+
+void TwoWire3::setSDA(uint8_t pin)
+{
+}
+
+void TwoWire3::setSCL(uint8_t pin)
+{
+}
+
+uint8_t TwoWire3::checkSIM_SCG()
+{
+	return ( SIM_SCGC1 & SIM_SCGC1_I2C3)? 1 : 0;  //Test to see if we have done a begin...
+
+}
+
+
+void TwoWire3::end()
+{
+	if (!(SIM_SCGC1 & SIM_SCGC1_I2C3)) return;
+	NVIC_DISABLE_IRQ(IRQ_I2C3);
+	KINETIS_I2C3.C1 = 0;
+
+	CORE_PIN56_CONFIG = 0;
+	CORE_PIN57_CONFIG = 0;
+
+	SIM_SCGC1 &= ~SIM_SCGC1_I2C3; // TODO: use bitband
+	TwoWire::end();
+}
+
+void i2c3_isr(void)
+{
+	if (Wire3.isr(Wire3._pwires, &KINETIS_I2C3) ) {
+		// Hack that mainline function says to set
+		attachInterrupt(Wire3.sda_pin_num, TwoWire3::sda_rising_isr, RISING);
+	}
+
+}
+
+// Detects the stop condition that terminates a slave receive transfer.
+// Sadly, the I2C in Kinetis K series lacks the stop detect interrupt
+// This pin change interrupt hack is needed to detect the stop condition
+void TwoWire3::sda_rising_isr(void)
+{
+	//digitalWrite(3, HIGH);
+	WIRE_STRUCT *pwires = Wire3._pwires;
+	if (!(I2C3_S & I2C_S_BUSY)) {
+		detachInterrupt(Wire3.sda_pin_num);
+		if (pwires->user_onReceive != NULL) {
+			pwires->rxBufferIndex = 0;
+			pwires->user_onReceive(pwires->rxBufferLength);
+		}
+		//delayMicroseconds(100);
+	} else {
+		if (++pwires->irqcount >= 2 || !pwires->slave_mode) {
+			detachInterrupt(Wire3.sda_pin_num);
+		}
+	}
+	//digitalWrite(3, LOW);
+}
+
+
+//TwoWire Wire = TwoWire();
+TwoWire3 Wire3;
+
+
+#endif //  __MK66FX1M0__ 
+


### PR DESCRIPTION
multiple I2C busses.
Example: T3.1/T3.2/T-LC - Support 2 so there is Wire and now Wire1
T3.5: has three I2C Busses, so it now has Wire, Wire1 and Wire2
T3.6: has four..... Wire3

For this, I Created a base class for the Wire objects, that has most of the functionality.
There are some virtual functions, which take care of the buss specific
things like, begin/end/setSCL/setSDA.

Also object keeps pointer to the I2C register structure for the buss and
got rid of most statitics.

With my first attempt, I found that this was eating up a significant amount of memory, as each Wire object has something like 80 data bytes associated with it. So I created an internal data structure, where I moved
the majority of the data members to.  This data structure is only allocated (malloc) when you call some members such as begin.  So there is not a large data hit for those programs that include Wire.h and only use 1 buss...

Tested on T3.6 with Wire talking to Wire3 both as Server and as client.  Also
tried Setting Wire to alternate pins to again talk to Wire3 with alternate pins for Wire.

Also tested with a modified version of SSD1306 I2C display and tried on all 4 busses of T3.6, also with Wire1 on T3.2 and T-LC.  Also tried Wire on T-LC.

Resolve issue where was timing out on some calls

Ran into issue that I would try to do a request from the client before
the previous ones stop bit was processed and we were clearing some
status.

Current fix is to loop up to 255 times checking for busy before
continuing...