### PR TITLE
Added APDS-9960 lux sensor at 0x39

### DIFF
--- a/examples/Scanner/Scanner.ino
+++ b/examples/Scanner/Scanner.ino
@@ -126,7 +126,7 @@ void printKnownChips(byte address)
     case 0x34: Serial.print(F("MAX11612,MAX11613")); break;
     case 0x35: Serial.print(F("MAX11616,MAX11617")); break;
     case 0x38: Serial.print(F("RA8875,FT6206")); break;
-    case 0x39: Serial.print(F("TSL2561")); break;
+    case 0x39: Serial.print(F("TSL2561, APDS9960")); break;
     case 0x3C: Serial.print(F("SSD1306,DigisparkOLED")); break;
     case 0x3D: Serial.print(F("SSD1306")); break;
     case 0x40: Serial.print(F("PCA9685,Si7021")); break;


### PR DESCRIPTION
Used in the sparkfun apds-9960 lux rgb proximity sensor boards and clones.