### PR TITLE
T4 bno80 issues - clock stretching, clear FIFO, 60mhz

### DIFF
--- a/WireIMXRT.cpp
+++ b/WireIMXRT.cpp
@@ -4,8 +4,13 @@
 
 #if defined(__IMXRT1052__) || defined(__IMXRT1062__)
 
-#include "debug/printf.h"
-
+//#include "debug/printf.h"
+//#define DEBUG_PRINTS
+#ifdef DEBUG_PRINTS
+#define DBGPrintf Serial.printf
+#else
+void inline DBGPrintf(...) {};
+#endif
 void TwoWire::begin(void)
 {
         // use 24 MHz clock
@@ -15,14 +20,16 @@ void TwoWire::begin(void)
     setClock(100000);
 
     // Setup SDA register
-	*(portControlRegister(hardware.sda_pins[sda_pin_index_].pin)) |= IOMUXC_PAD_PKE | IOMUXC_PAD_PUE | IOMUXC_PAD_PUS(3);
+	//*(portControlRegister(hardware.sda_pins[sda_pin_index_].pin)) |= IOMUXC_PAD_PKE | IOMUXC_PAD_PUE | IOMUXC_PAD_PUS(3);
+	*(portControlRegister(hardware.sda_pins[sda_pin_index_].pin)) = IOMUXC_PAD_ODE |IOMUXC_PAD_SRE |  IOMUXC_PAD_DSE(5)| IOMUXC_PAD_SPEED(1);
 	*(portConfigRegister(hardware.sda_pins[sda_pin_index_].pin)) = hardware.sda_pins[sda_pin_index_].mux_val;
 	if (hardware.sda_pins[sda_pin_index_].select_input_register) {
 	 	*(hardware.sda_pins[sda_pin_index_].select_input_register) =  hardware.sda_pins[sda_pin_index_].select_val;		
 	}	
 
 	// setup SCL register
-	*(portControlRegister(hardware.scl_pins[scl_pin_index_].pin)) |= IOMUXC_PAD_PKE | IOMUXC_PAD_PUE | IOMUXC_PAD_PUS(3);
+	//*(portControlRegister(hardware.scl_pins[scl_pin_index_].pin)) |= IOMUXC_PAD_PKE | IOMUXC_PAD_PUE | IOMUXC_PAD_PUS(3);
+	*(portControlRegister(hardware.scl_pins[scl_pin_index_].pin)) = IOMUXC_PAD_ODE |IOMUXC_PAD_SRE |  IOMUXC_PAD_DSE(5)| IOMUXC_PAD_SPEED(1);
 	*(portConfigRegister(hardware.scl_pins[scl_pin_index_].pin)) = hardware.scl_pins[scl_pin_index_].mux_val;
 	if (hardware.scl_pins[scl_pin_index_].select_input_register) {
 	 	*(hardware.scl_pins[scl_pin_index_].select_input_register) =  hardware.scl_pins[scl_pin_index_].select_val;		
@@ -123,32 +130,34 @@ uint8_t TwoWire::endTransmission(uint8_t sendStop)
 	if (!len) return 4; // no data to transmit
 
 	// wait while bus is busy
+	digitalWriteFast(0, HIGH);
 	while (1) {
 		status = port->MSR; // pg 2899 & 2892
 		if (!(status & LPI2C_MSR_BBF)) break; // bus is available
 		if (status & LPI2C_MSR_MBF) break; // we already have bus control
 		// TODO: timeout...
 	}
-	//printf("m=%x\n", status);
+	DBGPrintf("EndTrans=%x\n", status);
 
 	// Wonder if MFSR we should maybe clear it?
-	if ( port->MFSR & 0x7) {
+	if ( (port->MFSR & 0x7) && 
+			((port->MSR & (LPI2C_MSR_BBF|LPI2C_MSR_MBF)) != (LPI2C_MSR_BBF|LPI2C_MSR_MBF))) {
 		port->MCR = LPI2C_MCR_MEN | LPI2C_MCR_RTF;  // clear the FIFO
 		port->MSR = LPI2C_MSR_PLTF | LPI2C_MSR_ALF | LPI2C_MSR_NDF | LPI2C_MSR_SDF | LPI2C_MSR_FEF; // clear flags
-		//printf("Clear TX Fifo %lx %lx\n", port->MSR, port->MFSR);
+		DBGPrintf("Clear TX Fifo %lx %lx\n", port->MSR, port->MFSR);
 	}
 	// TODO: is this correct if the prior use didn't send stop?
 	//port->MSR = LPI2C_MSR_PLTF | LPI2C_MSR_ALF | LPI2C_MSR_NDF | LPI2C_MSR_SDF; // clear flags
 	port->MSR = status;
 
-	//printf("MSR=%lX, MFSR=%lX\n", status, port->MFSR);
-	//elapsedMillis timeout=0;
+	DBGPrintf("MSR=%lX, MFSR=%lX\n", status, port->MFSR);
+	elapsedMillis timeout=0;
 
 	while (1) {
 		// transmit stuff, if we haven't already
 		if (i <= len) {
 			uint32_t fifo_used = port->MFSR & 0x07; // pg 2914
-			//if (fifo_used < 4) printf("t=%ld\n", fifo_used);
+			if (fifo_used < 4) DBGPrintf("i=%d t=%ld\n", i, fifo_used);
 			while (fifo_used < 4) {
 				if (i == 0) {
 					//printf("start %x\n", txBuffer[0]);
@@ -167,15 +176,17 @@ uint8_t TwoWire::endTransmission(uint8_t sendStop)
 		// monitor status
 		status = port->MSR; // pg 2899 & 2892
 		if (status & LPI2C_MSR_ALF) {
-			//printf("arbitration lost\n");
+			DBGPrintf("arbitration lost\n");
+			digitalWriteFast(0, LOW);
 			return 4; // we lost bus arbitration to another master
 		}
 		if (status & LPI2C_MSR_NDF) {
-			//printf("NACK, f=%d, i=%d\n", port->MFSR & 0x07, i);
+			DBGPrintf("NACK, f=%d, i=%d\n", port->MFSR & 0x07, i);
 			// TODO: check that hardware really sends stop automatically
 			port->MCR = LPI2C_MCR_MEN | LPI2C_MCR_RTF;  // clear the FIFO
 			// TODO: is always sending a stop the right way to recover?
 			port->MTDR = LPI2C_MTDR_CMD_STOP;
+			digitalWriteFast(0, LOW);
 			return 2; // NACK for address
 			//return 3; // NACK for data TODO: how to discern addr from data?
 		}
@@ -184,10 +195,10 @@ uint8_t TwoWire::endTransmission(uint8_t sendStop)
 			//return 4;
 		//}
 
-		//if (timeout > 100) {
-			//printf("status = %x\n", status);
-			//timeout = 0;
-		//}
+		if (timeout > 100) {
+			DBGPrintf("status = %x\n", status);
+			timeout = 0;
+		}
 
 		if (sendStop) {
 			if (status & LPI2C_MSR_SDF) {
@@ -195,7 +206,10 @@ uint8_t TwoWire::endTransmission(uint8_t sendStop)
 				// types of errors, so this flag only means success
 				// when all comments in fifo have been fully used
 				uint32_t fifo = port->MFSR & 0x07;
-				if (fifo == 0) return 0;
+				if (fifo == 0)  {
+					digitalWriteFast(0, LOW);
+					return 0;
+				}
 			}
 		} else {
 			uint32_t fifo_used = port->MFSR & 0x07; // pg 2914
@@ -206,6 +220,7 @@ uint8_t TwoWire::endTransmission(uint8_t sendStop)
 				// TODO: this returns before the last data transmits!
 				// Should verify every byte ACKs, arbitration not lost
 				//printf("fifo empty, msr=%x\n", status);
+				digitalWriteFast(0, LOW);
 				return 0;
 			}
 		}
@@ -217,25 +232,30 @@ uint8_t TwoWire::requestFrom(uint8_t address, uint8_t length, uint8_t sendStop)
 	uint32_t cmd=0, status, fifo;
 
 	// wait while bus is busy
-	//printf("\nrequestFrom %x %x %x\n", address, length, sendStop);
+	DBGPrintf("\nrequestFrom %x %x %x\n", address, length, sendStop);
+	digitalWriteFast(1, HIGH);
+	digitalWriteFast(0, HIGH);
+
 	while (1) {
 		status = port->MSR; // pg 2899 & 2892
 		if (!(status & LPI2C_MSR_BBF)) break; // bus is available
 		if (status & LPI2C_MSR_MBF) break; // we already have bus control
 		// TODO: timeout...
 	}
-	//printf("idle2, msr=%x\n", status);
+	digitalWriteFast(0, LOW);
+	DBGPrintf("idle2, msr=%x\n", status);
 
 	// TODO: is this correct if the prior use didn't send stop?
 	port->MSR = LPI2C_MSR_PLTF | LPI2C_MSR_ALF | LPI2C_MSR_NDF | LPI2C_MSR_SDF | LPI2C_MSR_FEF; // clear flags
 
-	//printf("MSR=%lX, MCR:%lx, MFSR=%lX\n", status, port->MCR, port->MFSR);
+	DBGPrintf("MSR=%lX, MCR:%lx, MFSR=%lX\n", status, port->MCR, port->MFSR); Serial.flush();
 
 	// Wonder if MFSR we should maybe clear it?
-	if ( port->MFSR & 0x7) {
+	if ( (port->MFSR & 0x7) && 
+			((port->MSR & (LPI2C_MSR_BBF|LPI2C_MSR_MBF)) != (LPI2C_MSR_BBF|LPI2C_MSR_MBF))) {
 		port->MCR = LPI2C_MCR_MEN | LPI2C_MCR_RTF;  // clear the FIFO
 		port->MSR = LPI2C_MSR_PLTF | LPI2C_MSR_ALF | LPI2C_MSR_NDF | LPI2C_MSR_SDF | LPI2C_MSR_FEF; // clear flags
-		//printf("Clear TX Fifo %lx %lx\n", port->MSR, port->MFSR);
+		DBGPrintf("Clear TX Fifo %lx %lx\n", port->MSR, port->MFSR); Serial.flush();
 	}
 	address = (address & 0x7F) << 1;
 	if (length < 1) length = 1;
@@ -252,6 +272,9 @@ uint8_t TwoWire::requestFrom(uint8_t address, uint8_t length, uint8_t sendStop)
 			//if (fifo < 4) printf("t=%ld\n", fifo);
 			while (fifo < 4 && cmd < 3) {
 				if (cmd == 0) {
+					//if ((port->MSR & (LPI2C_MSR_BBF|LPI2C_MSR_MBF)) == (LPI2C_MSR_BBF|LPI2C_MSR_MBF)) {
+					//	DBGPrintf("BBF|MBF : ")
+					//}
 					port->MTDR = LPI2C_MTDR_CMD_START | 1 | address;
 				} else if (cmd == 1) {
 					// causes bus stuck... need way to recover
@@ -276,11 +299,11 @@ uint8_t TwoWire::requestFrom(uint8_t address, uint8_t length, uint8_t sendStop)
 		// monitor status
 		status = port->MSR; // pg 2899 & 2892
 		if (status & LPI2C_MSR_ALF) {
-			//printf("arbitration lost\n");
+			DBGPrintf("arbitration lost\n");
 			break;
 		}
 		if (status & LPI2C_MSR_NDF) {
-			//printf("got NACK\n");
+			DBGPrintf("got NACK\n");
 			// TODO: how to make sure stop is sent?
 			break;
 		}
@@ -295,6 +318,7 @@ uint8_t TwoWire::requestFrom(uint8_t address, uint8_t length, uint8_t sendStop)
 	//digitalWriteFast(15, HIGH);
 	//delayMicroseconds(2);
 	//digitalWriteFast(15, LOW);
+	digitalWriteFast(1, LOW);
 	return rxBufferLength;
 }
 
@@ -354,14 +378,14 @@ void TwoWire::setClock(uint32_t frequency)
 	if (frequency < 400000) {
 		// 100 kHz
 		port->MCCR0 = LPI2C_MCCR0_CLKHI(55) | LPI2C_MCCR0_CLKLO(59) |
-			LPI2C_MCCR0_DATAVD(25) | LPI2C_MCCR0_SETHOLD(40);
+			LPI2C_MCCR0_DATAVD(25) | LPI2C_MCCR0_SETHOLD(/*40*/18);
 		port->MCFGR1 = LPI2C_MCFGR1_PRESCALE(1);
 		port->MCFGR2 = LPI2C_MCFGR2_FILTSDA(5) | LPI2C_MCFGR2_FILTSCL(5) |
 			LPI2C_MCFGR2_BUSIDLE(3900);
 	} else if (frequency < 1000000) {
 		// 400 kHz
 		port->MCCR0 = LPI2C_MCCR0_CLKHI(26) | LPI2C_MCCR0_CLKLO(28) |
-			LPI2C_MCCR0_DATAVD(12) | LPI2C_MCCR0_SETHOLD(18);
+			LPI2C_MCCR0_DATAVD(12) | LPI2C_MCCR0_SETHOLD(/*10*/8);
 		port->MCFGR1 = LPI2C_MCFGR1_PRESCALE(0);
 		port->MCFGR2 = LPI2C_MCFGR2_FILTSDA(2) | LPI2C_MCFGR2_FILTSCL(2) |
 			LPI2C_MCFGR2_BUSIDLE(3900);


### PR DESCRIPTION
Hi @PaulStoffregen,

We ran into another Wire device that was not working at all on T4.  Which is the BNO80, which you can purchase from Sparkfun.  

Again Warning: I am Not an I2C expert, but have used...  Also @mjs513 has helped test out and these changes also incorporate his changes to run at 60Mhz to allow fast wire speeds. 
Those changes are in the PR #17 

Some of the things that were changed include:
a) Use slight more finesse when choosing to wipe the FIFO queue.  The last change for BNO55 was to clear it always if it entered the functions with the TX FIFO showing stuff in it.  But it looks like that was killing the repeat start stuff, that if you do a requestFrom  to get a count of bytes and then do another requestFrom, that second was wiping out and the previous byte was not properly NAKed... 

So now only kill pending FIFO if we BUS is not active and we are not the master... 

b) Clock stretching - I could be wrong, but the T4 RM talking about PINCFG shows the default is setup to do clock stretching, which is good, BUT, it also talks about that PAD needs to support it.

So I changed the PAD configuration for SCL/SDA to be Open Drain... Like it is on T3.x... 

c) Pulled in #17 - Which brought the clock speed to 60mhz and allowed us to use the example table values for the clock stuff.  (Table 46.9) as I was having issues with some of the current settings where the SETHOLD values were I think causing the start/restart timings to be REAL long time... 

