### PR TITLE
Qwiic keypad

### DIFF
--- a/WireIMXRT.h
+++ b/WireIMXRT.h
@@ -34,6 +34,9 @@
 
 #define BUFFER_LENGTH 32
 //#define WIRE_HAS_END 1
+#define WIRE_IMPLEMENT_WIRE
+#define WIRE_IMPLEMENT_WIRE1
+#define WIRE_IMPLEMENT_WIRE2
 
 class TwoWire : public Stream
 {

--- a/examples/Scanner/Scanner.ino
+++ b/examples/Scanner/Scanner.ino
@@ -139,8 +139,8 @@ void printKnownChips(byte address)
     case 0x47: Serial.print(F("PCA9685")); break;
     case 0x48: Serial.print(F("ADS1115,PN532,TMP102,LM75,PCF8591")); break;
     case 0x49: Serial.print(F("ADS1115,TSL2561,PCF8591")); break;
-    case 0x4A: Serial.print(F("ADS1115")); break;
-    case 0x4B: Serial.print(F("ADS1115,TMP102,BNO080")); break;
+    case 0x4A: Serial.print(F("ADS1115,Qwiic Keypad")); break;
+    case 0x4B: Serial.print(F("ADS1115,TMP102,BNO080,Qwiic Keypad")); break;
     case 0x50: Serial.print(F("EEPROM,FRAM")); break;
     case 0x51: Serial.print(F("EEPROM")); break;
     case 0x52: Serial.print(F("Nunchuk,EEPROM")); break;


### PR DESCRIPTION
@PaulStoffregen (@defragster @mjs513)
Two things:
Added QWIIC Keypad into the scanner sketch, I added its default address Same as the BNO080 as well as the one solder jumper alternate...  

Still not sure about adding the 16 possible address for the Qwiic Buttons... 

Second part was to add the defines: 
```
#define WIRE_IMPLEMENT_WIRE
#define WIRE_IMPLEMENT_WIRE1
#define WIRE_IMPLEMENT_WIRE2
```
to WireIMXRT.h - so that programs who may want to know which I2C busses exist, can look at these in the same way they can for T3.x/LC...

As an FYI, I added my version of the Scan all wire busses to our Wire Test board github project:
Which makes use of these defines, although currently it defines them locally for T4


