### PR TITLE
Fix issue with NACK during endTransmission

### DIFF
--- a/WireIMXRT.cpp
+++ b/WireIMXRT.cpp
@@ -120,6 +120,13 @@ uint8_t TwoWire::endTransmission(uint8_t sendStop)
 			port->MCR |= LPI2C_MCR_RTF | LPI2C_MCR_RRF; // clear FIFOs
 			return 4; // we lost bus arbitration to another master
 		}
+		
+		if (status & LPI2C_MSR_FEF) {
+			port->MCR |= LPI2C_MCR_RTF | LPI2C_MCR_RRF; // clear FIFOs
+			// empirical evidence suggests NOT trying to send a STOP condition!
+			return 5; // FIFO error
+		}
+		
 		if (status & LPI2C_MSR_NDF) {
 			port->MCR |= LPI2C_MCR_RTF | LPI2C_MCR_RRF; // clear FIFOs
 			port->MTDR = LPI2C_MTDR_CMD_STOP;


### PR DESCRIPTION
Reported as issue with M5Stack 8Angle, probably also affects other devices; FIFO error flag wasn't being checked in endTransmission(), and the 8Angle seems to be returning NACKs when writing the register number which appear to cause FIFO errors.

Appears to fix the issue reported at https://forum.pjrc.com/threads/72793-Teensy-4-1-I2C-issues-when-using-Audio, anyway.

Verified as working by OP in this post https://forum.pjrc.com/threads/72793-Teensy-4-1-I2C-issues-when-using-Audio?p=327031&viewfull=1#post327031